### PR TITLE
production builds for validator, option for accessible backend port

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,8 @@
 PORT_BACKEND=48090
 PORT_FRONTEND=48091
 PORT_VALIDATOR=48092
+# in production environments, set this port to 443
+#VITE_BACKEND_PORT=$PORT_BACKEND
 
 ## Scan Slots
 SCAN_SLOTS=10

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,7 +31,7 @@ services:
       target: prod
       args:
         - VITE_FOOTER_TEXT=${FOOTER_TEXT:-}
-        - VITE_BACKEND_PORT=443
+        - VITE_BACKEND_PORT=${VITE_BACKEND_PORT:-48090}
     container_name: frontend
     ports:
       - "${PORT_FRONTEND:-48091}:8080"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,7 +50,7 @@ services:
   validator:
     build:
       context: ./validator
-      target: dev
+      target: prod
     container_name: validator
     ports:
       - "${PORT_VALIDATOR:-48092}:8082"

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -5,22 +5,24 @@ WORKDIR /app
 ## Installs
 
 RUN npm install @secvisogram/csaf-validator-service
-RUN npm ci
 
 # Setup
 EXPOSE 8082
 
 COPY ./command.sh ./command.sh
-RUN chmod -x ./command.sh
+RUN chmod +x ./command.sh
 
 FROM build AS dev
 
 ## Command
 CMD ["sh", "/app/command.sh"]
 
-# FIXME
-FROM nginx:1.29.4 AS prod
+FROM node:22.21-alpine AS prod
 
-COPY --from=build /app/dist/client/browser /usr/share/nginx/html
+WORKDIR /app
 
-CMD ["sh", "/app/command.sh"]
+COPY --from=build /app/node_modules /app/node_modules
+
+EXPOSE 8082
+
+CMD ["sh", "-c", "cd /app/node_modules/@secvisogram/csaf-validator-service && npm start"]


### PR DESCRIPTION
build: prod builds for validator
fixes https://github.com/csaf-tools/provider-online-check/issues/47

build: make vite backend port configurable
the port at which the backend will be accessible for the user -> make this a config
allows running the prod environment easily, and on prod envs, only make one switch