### PR TITLE
Bugfix: Error Status Propagation

### DIFF
--- a/backend/src/csaf/csaf_checker.py
+++ b/backend/src/csaf/csaf_checker.py
@@ -227,7 +227,7 @@ class CSAF_Checker(BaseModel):
 
         if exitCode != 0:
             logger.info(
-                f"Task exited with code {exitCode} and error message: {errorMsg}"
+                f"{data.csaf_checker_output_runtime_log} \nTask exited with code {exitCode} and error message: {errorMsg} \nLast CSAF output has been prepended"
             )
             return (exitCode, errorMsg)
 
@@ -241,7 +241,7 @@ class CSAF_Checker(BaseModel):
         else:
             return (
                 1,
-                f"CSAF Process ended with status code {exitCode} and error message: {errorMsg}",
+                f"{data.csaf_checker_output_runtime_log} \nTask exited with code {exitCode} and error message: {errorMsg} \nLast CSAF output has been prepended",
             )
 
     async def run(self, data: Domain_Task_Data) -> (int, str):

--- a/backend/src/router/router.py
+++ b/backend/src/router/router.py
@@ -25,9 +25,10 @@ router = APIRouter()
 
 logger = logging.getLogger(__name__)
 
-ENV_CSAF_CHECKER_VERSION="CSAF_CHECKER_VERSION"
-ENV_CSAF_VALIDATOR_VERSION="CSAF_VALIDATOR_VERSION"
-ENV_CSAF_PROVIDER_VERSION="APP_VERSION"
+ENV_CSAF_CHECKER_VERSION = "CSAF_CHECKER_VERSION"
+ENV_CSAF_VALIDATOR_VERSION = "CSAF_VALIDATOR_VERSION"
+ENV_CSAF_PROVIDER_VERSION = "APP_VERSION"
+
 
 @router.post(
     "/scan/start",
@@ -88,7 +89,7 @@ async def start_scan(request: ScanRequest) -> Dict[str, Any]:
 
         if data is None or errorMsg != "":
             return {
-                "status": ScanResponseStatus.INITIALIZED,
+                "status": ScanResponseStatus.ERROR,
                 "domain": request.domain,
                 "error": errorMsg,
             }
@@ -102,6 +103,7 @@ async def start_scan(request: ScanRequest) -> Dict[str, Any]:
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to start scan: {str(e)}")
+
 
 @router.get("/information", summary="General Provider Information", tags=["meta"])
 async def meta_info() -> Dict[str, Any]:

--- a/backend/src/router/scan_request.py
+++ b/backend/src/router/scan_request.py
@@ -30,7 +30,7 @@ class ScanRequest(BaseModel):
         bool,
         Field(
             description="Stops and clears any slots that are already checking or have recently checked the requested domain"
-        )
+        ),
     ] = False
 
     @field_validator("domain")

--- a/backend/src/router/scan_request.py
+++ b/backend/src/router/scan_request.py
@@ -26,6 +26,13 @@ class ScanRequest(BaseModel):
         ),
     ] = False
 
+    clear_any_running: Annotated[
+        bool,
+        Field(
+            description="Stops and clears any slots that are already checking or have recently checked the requested domain"
+        )
+    ] = False
+
     @field_validator("domain")
     def _validate_domain(cls, value):
         """

--- a/backend/src/slots/domain_task.py
+++ b/backend/src/slots/domain_task.py
@@ -165,10 +165,10 @@ class Domain_Task(BaseModel):
     def on_interrupt(self):
         self.status = Domain_Task_Status.INTERRUPTED
 
-    def on_error(self, string):
+    def on_error(self, errMsg):
         self.status = Domain_Task_Status.ERROR
 
-        logger.error(f"Domain Task Error: {string}")
+        logger.error(f"Domain Task Error: {errMsg}")
 
     def get_status(self) -> Domain_Task_Status:
         return self.status

--- a/backend/src/slots/slot_manager.py
+++ b/backend/src/slots/slot_manager.py
@@ -86,7 +86,9 @@ class Slot_Manager:
                 logger.info(
                     f"A task is already operating for {request.domain} in slot id {slot_with_identical_running_task.id}"
                 )
-                return slot_with_identical_running_task.running_task.get_data(False).uuid
+                return slot_with_identical_running_task.running_task.get_data(
+                    False
+                ).uuid
 
         # Find available slot
         if available_slot is None:

--- a/backend/src/slots/slot_manager.py
+++ b/backend/src/slots/slot_manager.py
@@ -75,19 +75,26 @@ class Slot_Manager:
 
         # Search for a running task that operates on the same domain
         # Return that task id, if it exists (avoid working on the same domain twice)
+        available_slot = None
         slot_with_identical_running_task = self.get_slot_by_domain(request.domain)
         if slot_with_identical_running_task is not None:
-            logger.info(
-                f"A task is already operating for {request.domain} in slot id {slot_with_identical_running_task.id}"
-            )
-            return slot_with_identical_running_task.running_task.get_data(False).uuid
+            if request.clear_any_running:
+                slot_with_identical_running_task.running_task.stop_task()
+
+                available_slot = slot_with_identical_running_task
+            else:
+                logger.info(
+                    f"A task is already operating for {request.domain} in slot id {slot_with_identical_running_task.id}"
+                )
+                return slot_with_identical_running_task.running_task.get_data(False).uuid
 
         # Find available slot
-        available_slot = self.find_first_available_slot()
         if available_slot is None:
-            # FIXME: Throw some kind of error
-            logger.info("No available slot found")
-            return ""
+            available_slot = self.find_first_available_slot()
+            if available_slot is None:
+                # FIXME: Throw some kind of error
+                logger.info("No available slot found")
+                return ""
 
         logger.info(
             f"For scan request of domain {request.domain}, slot {available_slot.id} is available"

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -10,7 +10,8 @@ client = TestClient(app)
 def mock_scan_request_variable_domain(domain: str):
     mock = {
         "session_id": "0",
-        "domain": domain
+        "domain": domain,
+        "clear_any_running": True,
     }
     return mock
 
@@ -18,7 +19,8 @@ def mock_scan_request_variable_domain(domain: str):
 def mock_scan_request_variable_session_id(session_id: str):
     mock = {
         "session_id": session_id,
-        "domain": "example.com"
+        "domain": "example.com",
+        "clear_any_running": True,
     }
     return mock
 


### PR DESCRIPTION
When a backend error occurs, the status that is being propagated does not reflect an erroneous state
Resolves https://github.com/csaf-tools/provider-online-check/issues/86#issuecomment-4431012617