### PR TITLE
Group scan results by type, option to show JSON output

### DIFF
--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -14,16 +14,16 @@ describe("Testing App...", () => {
     })
 
     test('extractMessages', () => {
-        app.vm.extractMessages([{ messages: [{text: "Test1", type: 0}]}])
-        expect(app.vm.messagesList).toStrictEqual([{text: "Test1", type: 0}])
+        app.vm.extractMessages([{ messages: [{text: "Test1", type: 0}], num: 11}])
+        expect(app.vm.messagesList).toStrictEqual([{text: "Test1", type: 0, num:11}])
         app.vm.extractMessages([{messages: undefined}])
         expect(app.vm.messagesList).toStrictEqual([])
     }),
     test('extractMessagesFromResultsChecker with json string', () =>{
         app.vm.extractMessagesFromResultsChecker(
-            '{ "domains": [{"requirements": [{ "messages": [{"text": "Test1", "type": 0}]}]}]}'
+            '{ "domains": [{"requirements": [{ "messages": [{"text": "Test1", "type": 0}], "num": 11 }]}]}'
         )
-        expect(app.vm.messagesList).toStrictEqual([{text: "Test1", type: 0}])
+        expect(app.vm.messagesList).toStrictEqual([{text: "Test1", type: 0, num: 11}])
     }),
     test('extractMessagesFromResultsChecker with requirements null', () => {
         app.vm.extractMessagesFromResultsChecker(
@@ -33,9 +33,9 @@ describe("Testing App...", () => {
     }),
     test('extractMessagesFromResultsChecker with object', () => {
         app.vm.extractMessagesFromResultsChecker(
-            { "domains": [{"requirements": [{ "messages": [{"text": "Test1", "type": 0}]}]}]}
+            { "domains": [{"requirements": [{ "messages": [{"text": "Test1", "type": 0}], "num": 11}]}]}
         )
-        expect(app.vm.messagesList).toStrictEqual([{text: "Test1", type: 0}])
+        expect(app.vm.messagesList).toStrictEqual([{text: "Test1", type: 0, num: 11}])
     }),
     test('resultClass', () => {
         const test_oracle = [
@@ -84,7 +84,7 @@ describe("Testing App...", () => {
         vi.spyOn(axios, 'post').mockImplementation(() => { 
             return {data: {
                 status: "CACHED_CHECKER",
-                results_checker: { "domains": [{"requirements": [{ "messages": [{"text": "Test1", "type": 0}]}]}]}
+                results_checker: { "domains": [{"requirements": [{ "messages": [{"text": "Test1", "type": 0}], "num": 12 }]}]}
             }}
         })
         app.vm.domain = "Test"
@@ -92,7 +92,7 @@ describe("Testing App...", () => {
         await flushPromises()
         expect(app.vm.loading).toBe(false)
         expect(app.vm.result?.status).toBe('CACHED_CHECKER')
-        expect(app.vm.messagesList).toStrictEqual([{text: 'Test1', type: 0}])
+        expect(app.vm.messagesList).toStrictEqual([{text: 'Test1', type: 0, num: 12}])
 
     })
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -49,6 +49,17 @@
                 <div v-else-if="result?.status === 'CACHED_CHECKER'">
                   <h5 class="alert-heading">Scan found in cache</h5>
                 </div>
+                
+                <h6 :class="publisherStatus">CSAF publisher</h6>
+                <Message v-for="item of publisherMessages" :text="item.text" :type="item.type"></Message> 
+                
+                <h6 :class="providerStatus">CSAF provider</h6>
+                <Message v-for="item of providerMessages" :text="item.text" :type="item.type"></Message> 
+                
+                <h6 :class="trustedProviderStatus">CSAF trusted provider</h6>
+                <Message v-for="item of trustedProviderMessages" :text="item.text" :type="item.type"></Message> 
+
+                <h6>All messages</h6>
                 <Message v-for="item of messagesList" :text="item.text" :type="item.type"></Message>
               </div>
 
@@ -188,7 +199,63 @@ export default defineComponent({
     },
     footerText() {
       return import.meta.env.VITE_FOOTER_TEXT || ''
-    }
+    },
+    publisherMessages() {
+      if (this.messagesList) {
+        return this.messagesList.filter(msg => [1, 2, 3, 4].includes(msg.num))
+      }
+      return null
+    },
+    publisherStatus() {
+      if (this.publisherMessages) {
+        return this.publisherMessages.filter(msg => msg.type === 2).length === 0 ? 'text-green' : 'text-red'
+      }
+      return 'text-red'
+    },
+    providerMessages() {
+      if (this.messagesList) {
+        const providerMessages = []
+        providerMessages.push(
+          this.publisherStatus === 'text-green'
+            ? {text: 'Is a valid CSAF publisher', type: 0 }
+            : {text: 'Is not a valid CSAF publisher', type: 2 }
+        )
+        providerMessages.push(...(this.messagesList.filter(msg => [5, 6, 7].includes(msg.num))))
+        const dirBaseMessages = this.messagesList.filter(msg => [11,12,13,14].includes(msg.num))
+        const rolieBaseMessages = this.messagesList.filter(msg => [15,16,17].includes(msg.num))
+        if (rolieBaseMessages.filter(msg => msg.type === 2).length <= dirBaseMessages.filter(msg => msg.type === 2).length) {
+          providerMessages.push(...rolieBaseMessages)
+        } else {
+          providerMessages.push(...dirBaseMessages)
+        }
+        return providerMessages
+      }
+      return null
+    },
+    providerStatus() {
+      if (this.providerMessages) {
+        return this.providerMessages.filter(msg => msg.type === 2).length === 0 ? 'text-green' : 'text-red'
+      }
+      return 'text-red'
+    },
+    trustedProviderMessages() {
+      if (this.messagesList) {
+        const trustedProviderMessages = []
+        trustedProviderMessages.push(
+          this.providerStatus === 'text-green' ? {text: 'Is valid CSAF provider', type: 0 }
+                                              : {text: 'Is not a valid CSAF provider', type: 2})
+        const filtered = this.messagesList.filter(msg => [18,19,20].includes(msg.num))
+        trustedProviderMessages.push(...filtered)
+        return trustedProviderMessages
+      }
+      return null
+    },
+    trustedProviderStatus() {
+      if (this.trustedProviderMessages) {
+        return this.trustedProviderMessages.filter(msg => msg.type === 2).length === 0 ? 'text-green' : 'text-red'
+      }
+      return 'text-red'
+    },
   },
   methods: {
     async startScan() {
@@ -232,7 +299,7 @@ export default defineComponent({
       this.messagesList = []
       for (const req of requirements) {
         for (const msg2 of req.messages ?? []) {
-          this.messagesList.push(msg2)
+          this.messagesList.push({type: msg2.type, text: msg2.text, num: req.num })
         }
       }
     }
@@ -244,5 +311,11 @@ export default defineComponent({
 #app {
   min-height: 100vh;
   background-color: #f8f9fa;
+}
+.text-green {
+  color: green;
+}
+.text-red {
+  color: red;
 }
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -59,10 +59,28 @@
                 <h6 :class="trustedProviderStatus" class="small-margin-top">CSAF trusted provider</h6>
                 <Message v-for="item of trustedProviderMessages" :text="item.text" :type="item.type"></Message> 
 
-                <h6 class="small-margin-top">All messages</h6>
-                <Message v-for="item of messagesList" :text="item.text" :type="item.type"></Message>
+                <p class="small-margin-top">
+                    <a class="btn btn-primary" data-bs-toggle="collapse" href="#collapseAllMessages" role="button" aria-expanded="false" aria-controls="collapseAllMessages">
+                      Display all messages
+                    </a>
+                    &nbsp;
+                    <a class="btn btn-primary" data-bs-toggle="collapse" href="#collapseResultOutput" role="button" aria-expanded="false" aria-controls="collapseResultOutput">
+                      Display result output
+                    </a>
+                </p>
+                <div class="collapse" id="collapseAllMessages">
+                  <div class="card card-body">
+                    <h6>All messages:</h6>
+                    <Message v-for="item of messagesList" :text="item.text" :type="item.type"></Message>
+                  </div>
+                </div>
+                <div class="collapse" id="collapseResultOutput">
+                  <div class="card card-body">
+                    <h6>Result of the checker (for debug):</h6>
+                    {{ result?.results_checker }}
+                  </div>
+                </div>
               </div>
-
               <div 
                 v-if="result && ['ERROR', 'UNDEFINED', 'INITIALIZED', 'RUNNING_CHECKER', 'PAUSED'].includes(result?.status)"
                 class="mt-4"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -50,16 +50,16 @@
                   <h5 class="alert-heading">Scan found in cache</h5>
                 </div>
                 
-                <h6 :class="publisherStatus">CSAF publisher</h6>
+                <h6 :class="publisherStatus" class="small-margin-top">CSAF publisher</h6>
                 <Message v-for="item of publisherMessages" :text="item.text" :type="item.type"></Message> 
                 
-                <h6 :class="providerStatus">CSAF provider</h6>
+                <h6 :class="providerStatus" class="small-margin-top">CSAF provider</h6>
                 <Message v-for="item of providerMessages" :text="item.text" :type="item.type"></Message> 
                 
-                <h6 :class="trustedProviderStatus">CSAF trusted provider</h6>
+                <h6 :class="trustedProviderStatus" class="small-margin-top">CSAF trusted provider</h6>
                 <Message v-for="item of trustedProviderMessages" :text="item.text" :type="item.type"></Message> 
 
-                <h6>All messages</h6>
+                <h6 class="small-margin-top">All messages</h6>
                 <Message v-for="item of messagesList" :text="item.text" :type="item.type"></Message>
               </div>
 
@@ -317,5 +317,8 @@ export default defineComponent({
 }
 .text-red {
   color: red;
+}
+.small-margin-top {
+  margin-top: 15px;
 }
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -61,11 +61,11 @@
 
                 <p class="small-margin-top">
                     <a class="btn btn-primary" data-bs-toggle="collapse" href="#collapseAllMessages" role="button" aria-expanded="false" aria-controls="collapseAllMessages">
-                      Display all messages
+                      Show all messages
                     </a>
                     &nbsp;
                     <a class="btn btn-primary" data-bs-toggle="collapse" href="#collapseResultOutput" role="button" aria-expanded="false" aria-controls="collapseResultOutput">
-                      Display result output
+                      Show JSON output
                     </a>
                 </p>
                 <div class="collapse" id="collapseAllMessages">
@@ -77,7 +77,10 @@
                 <div class="collapse" id="collapseResultOutput">
                   <div class="card card-body">
                     <h6>Result of the checker (for debug):</h6>
-                    {{ result?.results_checker }}
+                    <div class="d-flex justify-content-end mb-2">
+                      <button class="btn btn-sm btn-outline-secondary" @click="copyResultToClipboard">Copy to clipboard</button>
+                    </div>
+                    <pre>{{ result?.results_checker }}</pre>
                   </div>
                 </div>
               </div>
@@ -239,6 +242,7 @@ export default defineComponent({
             : {text: 'Is not a valid CSAF publisher', type: 2 }
         )
         providerMessages.push(...(this.messagesList.filter(msg => [5, 6, 7].includes(msg.num))))
+        // TODO 8 or 9 or 10
         const dirBaseMessages = this.messagesList.filter(msg => [11,12,13,14].includes(msg.num))
         const rolieBaseMessages = this.messagesList.filter(msg => [15,16,17].includes(msg.num))
         if (rolieBaseMessages.filter(msg => msg.type === 2).length <= dirBaseMessages.filter(msg => msg.type === 2).length) {
@@ -320,6 +324,9 @@ export default defineComponent({
           this.messagesList.push({type: msg2.type, text: msg2.text, num: req.num })
         }
       }
+    },
+    copyResultToClipboard() {
+      navigator.clipboard.writeText(JSON.stringify(this.result?.results_checker, null, 2))
     }
   }
 })


### PR DESCRIPTION
Part of #70 

- use the roles 'publisher', 'provider' and 'trusted provider' to order the messages.
- add code to check if a domain has that role.
- add two collapse items : all messages and the result_checker for debug

The roles of a domain and their rules are taken form csaf v2.0 spec (topic 7).