### PR TITLE
Update result layout: larger headers and better diff messages

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -44,19 +44,19 @@
               <!-- display of requirements messages -->
               <div v-if="messagesList" class="mt-4">
                 <div v-if="result?.status === 'DONE_CHECKER'">
-                  <h5 class="alert-heading">Scan Done</h5>
+                  <h3 class="alert-heading">Scan Done</h3>
                 </div>
                 <div v-else-if="result?.status === 'CACHED_CHECKER'">
-                  <h5 class="alert-heading">Scan found in cache</h5>
+                  <h3 class="alert-heading">Scan found in cache</h3>
                 </div>
                 
-                <h6 :class="publisherStatus" class="small-margin-top">CSAF publisher</h6>
+                <h4 :class="publisherStatus" class="small-margin-top">CSAF publisher</h4>
                 <Message v-for="item of publisherMessages" :text="item.text" :type="item.type"></Message> 
                 
-                <h6 :class="providerStatus" class="small-margin-top">CSAF provider</h6>
+                <h4 :class="providerStatus" class="small-margin-top">CSAF provider</h4>
                 <Message v-for="item of providerMessages" :text="item.text" :type="item.type"></Message> 
                 
-                <h6 :class="trustedProviderStatus" class="small-margin-top">CSAF trusted provider</h6>
+                <h4 :class="trustedProviderStatus" class="small-margin-top">CSAF trusted provider</h4>
                 <Message v-for="item of trustedProviderMessages" :text="item.text" :type="item.type"></Message> 
 
                 <p class="small-margin-top">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -50,13 +50,13 @@
                   <h3 class="alert-heading">Scan found in cache</h3>
                 </div>
                 
-                <h4 :class="publisherStatus" class="small-margin-top">CSAF publisher</h4>
+                <h4 :class="publisherStatus" class="small-margin-top medium-font-size">CSAF publisher</h4>
                 <Message v-for="item of publisherMessages" :text="item.text" :type="item.type"></Message> 
                 
-                <h4 :class="providerStatus" class="small-margin-top">CSAF provider</h4>
+                <h4 :class="providerStatus" class="small-margin-top medium-font-size">CSAF provider</h4>
                 <Message v-for="item of providerMessages" :text="item.text" :type="item.type"></Message> 
                 
-                <h4 :class="trustedProviderStatus" class="small-margin-top">CSAF trusted provider</h4>
+                <h4 :class="trustedProviderStatus" class="small-margin-top medium-font-size">CSAF trusted provider</h4>
                 <Message v-for="item of trustedProviderMessages" :text="item.text" :type="item.type"></Message> 
 
                 <p class="small-margin-top">
@@ -352,5 +352,8 @@ export default defineComponent({
 }
 .small-margin-top {
   margin-top: 15px;
+}
+.medium-font-size {
+  font-size: 1.3rem;
 }
 </style>

--- a/frontend/src/Message.vue
+++ b/frontend/src/Message.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="messageClass">
+    <div :class="messageClass" class="small-bottom-margin">
         {{ text }}
     </div>
 </template>
@@ -37,6 +37,9 @@ color: orange;
 }
 .text-red {
 color: red;
+}
+.small-bottom-margin {
+    margin-bottom: 12px;
 }
 </style>
 


### PR DESCRIPTION
Small layout improvement

- use larger headers to differ role header from messages
- add a small margin to diff different messages ( so it could be seen, what is one msg and what is the next message)