### PR TITLE
API Docs: fix routing and CSP

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ app = FastAPI(
     title="CSAF Provider Scan API",
     description="API for scanning CSAF providers",
     version=os.getenv("APP_VERSION"),
-    docs_url="/api/docs",
+    docs_url=None,  # provided by the custom function custom_swagger_ui below
     redoc_url="/api/redoc",
     openapi_url="/api/openapi.json",
 )
@@ -33,6 +33,7 @@ async def custom_swagger_ui():
     return get_swagger_ui_html(
         openapi_url="/api/openapi.json",
         title="CSAF Provider Scan API",
+        swagger_favicon_url="data:,",  # disables loading the favicon from an external source
         **swagger_ui_kwargs,
     )
 

--- a/contrib/apache-site.conf
+++ b/contrib/apache-site.conf
@@ -23,7 +23,10 @@ MDCertificateAgreement accepted
     Header always set X-Frame-Options "SAMEORIGIN"
     Header always set X-Content-Type-Options "nosniff"
     Header always set Referrer-Policy "strict-origin-when-cross-origin"
-    Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
+    Header always set Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'"
+    <Location /api/docs>
+        Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self'"
+    </Location>
 
     # Access control
     # Edit files in contrib/blocklists/, run contrib/update-blocklists.sh, then reload Apache.


### PR DESCRIPTION
- adapt the routing so that the custom API docs function is used
- disable the favicon, we don't load external resources anyway
- and adapt the CSP: only allow unsafe scripts for the API docs where it is necessary

The code is already running on https://check.provider.csaf.dev/