### PR TITLE
Update scan result width, messages lines and blocks

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,7 +8,7 @@
 
     <div class="container mt-5">
       <div class="row justify-content-center">
-        <div class="col-md-8">
+        <div class="col-md-12">
           <div class="card shadow">
             <div class="card-body">
               <h2 class="card-title mb-4">Scan a Domain <span class="badge bg-warning ms-2" style="font-size: 0.4em; vertical-align: middle;">Experimental</span></h2>
@@ -143,7 +143,7 @@
       </div>
 
       <div v-if="recentScans.length > 0" class="row justify-content-center mt-4">
-        <div class="col-md-8">
+        <div class="col-md-12">
           <div class="card">
             <div class="card-body">
               <h5 class="card-title">Recently Scanned</h5>
@@ -169,7 +169,7 @@
       </div>
 
       <div class="row justify-content-center mt-4">
-        <div class="col-md-8">
+        <div class="col-md-12">
           <div class="card">
             <div class="card-body">
               <h5 class="card-title">About</h5>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -50,13 +50,11 @@
                   <h3 class="alert-heading">Scan found in cache</h3>
                 </div>
 
-                <h4 :class="publisherStatus" class="small-margin-top medium-font-size">CSAF publisher</h4>
-                <MessageLine v-for="item of publisherMessages" :key="item.text" :text="item.text" :type="item.type"></MessageLine>
-
-                <h4 :class="providerStatus" class="small-margin-top medium-font-size">CSAF provider</h4>
-                <MessageLine v-for="item of providerMessages" :key="item.text" :text="item.text" :type="item.type"></MessageLine>
-
-                <h4 :class="trustedProviderStatus" class="small-margin-top medium-font-size">CSAF trusted provider</h4>
+                <h4 :class="trustedProviderStatus" class="small-margin-top medium-font-size">
+                  <span v-if="trustedProviderStatus === 'text-green'">PASSED:</span>
+                  <span v-else>FAILED:</span>
+                  CSAF trusted provider
+                </h4>
                 <MessageLine v-for="item of trustedProviderMessages" :key="item.text" :text="item.text" :type="item.type"></MessageLine>
 
                 <p class="small-margin-top">
@@ -281,32 +279,17 @@ export default defineComponent({
     footerText() {
       return import.meta.env.VITE_FOOTER_TEXT || ''
     },
-    publisherMessages() {
+    trustedProviderMessages() {
       if (this.messagesList) {
+        const trustedProviderMessages = []
+
         // requirements 1 (Valid CSAF document), 2 (Filename), 3 (TLS), 4 (TLP:WHITE)
         // Show all messages
-        return this.filterMessageListByNums([1, 2, 3, 4])
-      }
-      return null
-    },
-    publisherStatus() {
-      if (this.publisherMessages) {
-        return this.publisherMessages.filter((msg: MessageData) => msg.type === 2).length === 0 ? 'text-green' : 'text-red'
-      }
-      return 'text-red'
-    },
-    providerMessages() {
-      if (this.messagesList) {
-        const providerMessages = []
-        providerMessages.push(
-          this.publisherStatus === 'text-green'
-            ? {text: 'Is a valid CSAF publisher', type: 0 }
-            : {text: 'Is not a valid CSAF publisher', type: 2 }
-        )
+        trustedProviderMessages.push(...this.filterMessageListByNums([1, 2, 3, 4]))
 
         // requirements 5 (TLP:AMBER and TLP:RED), 6 (Redirects) and 7 (provider-metadata.json)
         // Show all messages
-        providerMessages.push(...this.filterMessageListByNums([5, 6, 7]))
+        trustedProviderMessages.push(...this.filterMessageListByNums([5, 6, 7]))
 
         // requirements min one of 8 (security.txt), 9 (Well-known URL for provider-metadata.json), 10 (DNS path)
         // One must succed, then show that message, else show all messages
@@ -314,13 +297,13 @@ export default defineComponent({
         const req9Messages = this.filterMessageListByNums([9])
         const req10Messages = this.filterMessageListByNums([10])
         if (req8Messages.length > 0  && req8Messages.filter((msg:MessageData) => msg.type === 2).length === 0) {
-          providerMessages.push(...req8Messages)
+          trustedProviderMessages.push(...req8Messages)
         } else if (req9Messages.length > 0  && req9Messages.filter((msg:MessageData) => msg.type === 2).length === 0) {
-          providerMessages.push(...req9Messages)
+          trustedProviderMessages.push(...req9Messages)
         } else if (req10Messages.length > 0  && req10Messages.filter((msg:MessageData) => msg.type === 2).length === 0) {
-          providerMessages.push(...req10Messages)
+          trustedProviderMessages.push(...req10Messages)
         } else {
-          providerMessages.push(...req8Messages, ...req9Messages, ...req10Messages)
+          trustedProviderMessages.push(...req8Messages, ...req9Messages, ...req10Messages)
         }
 
         // requirements dir based 11 (One folder per year), 12 (index.txt), 13 (changes.csv), 14 (Directory listings)
@@ -330,26 +313,10 @@ export default defineComponent({
         const rolieBaseMessages = this.filterMessageListByNums([15, 16, 17])
         if (rolieBaseMessages.filter((msg:MessageData) => msg.type === 2).length
             <= dirBaseMessages.filter((msg: MessageData) => msg.type === 2).length) {
-          providerMessages.push(...rolieBaseMessages)
+          trustedProviderMessages.push(...rolieBaseMessages)
         } else {
-          providerMessages.push(...dirBaseMessages)
+          trustedProviderMessages.push(...dirBaseMessages)
         }
-        return providerMessages
-      }
-      return null
-    },
-    providerStatus() {
-      if (this.providerMessages) {
-        return this.providerMessages.filter(msg => msg.type === 2).length === 0 ? 'text-green' : 'text-red'
-      }
-      return 'text-red'
-    },
-    trustedProviderMessages() {
-      if (this.messagesList) {
-        const trustedProviderMessages = []
-        trustedProviderMessages.push(
-          this.providerStatus === 'text-green' ? {text: 'Is valid CSAF provider', type: 0 }
-                                              : {text: 'Is not a valid CSAF provider', type: 2})
 
         // requirements 18 (Integrity), 19 (Signatures), 20 (Public OpenPGP Key)
         // Show all messages

--- a/frontend/src/MessageLine.spec.ts
+++ b/frontend/src/MessageLine.spec.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils'
 import MessageLine from './MessageLine.vue'
 
 describe("Testing MessageLine...", () => {
-    let message: any
+    let message = mount(MessageLine , {props: { type: 0}})
     beforeEach(()=> {
         message = mount(MessageLine , {props: { type: 0}})
     })

--- a/frontend/src/MessageLine.vue
+++ b/frontend/src/MessageLine.vue
@@ -1,5 +1,8 @@
 <template>
-    <div :class="messageClass" class="small-bottom-margin">
+    <div class="small-bottom-margin">
+        <span v-if="type === 2" :class="messageClass">ERROR</span>
+        <span v-else-if="type === 1" :class="messageClass">WARN</span>
+        <span v-else :class="messageClass">PASS</span>
         {{ text }}
     </div>
 </template>


### PR DESCRIPTION
Resolve part of #70 

Some small changes to the scan result display:
- Update the width of the main component from col-8 to col-12
- Update the message lines components: Don't relay only on color, add PASS, WARN, ERR
- Update the displayed blocks, only trusted provider and update the header