### PR TITLE
Fix: Linting make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint:
 	bash backend/dev/run-lint.sh -l -b
 
 lint-containerd:
-	make dev-exec "backend bash dev/run-lint.sh -l -i"
+	make dev-exec EXEC_COMMAND="backend bash dev/run-lint.sh -l -i"
 
 lint-containerd-standalone:
 	bash backend/dev/run-lint.sh

--- a/backend/dev/run-lint.sh
+++ b/backend/dev/run-lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Executes all linters. Should errors occur, CATCH will be set to 1, causing an erroneous exit code.
+# Executes all linters
 
 echo "Run Linters"
 
@@ -38,13 +38,12 @@ then
     trap 'if [ -z "$LOCAL" ]; then make dev-stop; fi' EXIT
 
     # Setup
-    make dev-attached
+    make dev-detached
 
-    "Linting"
     # Container Mode
-    eval "$DC exec -T backend black --check --diff ${PATHS}"
-    eval "$DC exec -T backend isort --check-only --diff ${PATHS}"
-    eval "$DC exec -T backend flake8 --ignore=E501 ${PATHS}"
+    eval "$DC exec backend black ${PATHS}"
+    eval "$DC exec backend isort ${PATHS}"
+    eval "$DC exec backend flake8 --ignore=E501 ${PATHS}"
 
 else
     # Local Mode


### PR DESCRIPTION
As https://github.com/csaf-tools/provider-online-check/issues/104 points out, lint-containerd and lint-containerd-standalone were not properly implemented. This PR fixed both targets to make them work as intended