### PR TITLE
Fix: Disable domain inputs without a dot

### DIFF
--- a/backend/src/validators/request_validator.py
+++ b/backend/src/validators/request_validator.py
@@ -11,7 +11,7 @@ from ..database.redis import Redis_Controller
 
 # Basic domain validation pattern (same as before)
 DOMAIN_PATTERN = (
-    r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*"
+    r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+"
     r"[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$"
 )
 


### PR DESCRIPTION
Currently users are able to input domains such as "inter" or "xyz" which lack a domain extension. A simple fix to the domain validator regex blocks these types of inputs