### PR TITLE
Use/add clearFields method

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -197,7 +197,7 @@ interface AppData {
   messagesList: null | MessageData[];
   scanTime: null | string;
   passed: boolean;
-  role: string;
+  role: string | null;
   version: {
     csaf_checker_version: string;
     csaf_validator_version: string;
@@ -316,6 +316,7 @@ export default defineComponent({
       this.loading = true
       this.result = null
       this.error = null
+      this.clearFields()
 
       try {
         const response = await axios.post(`${this.backendUrl}/api/scan/start`, {
@@ -330,12 +331,10 @@ export default defineComponent({
           this.setPassed(parsedResultsChecker)
           this.setRole(parsedResultsChecker)
         } else {
-          this.messagesList = null
-          this.scanTime = null
+          this.clearFields()
         }
       } catch (err: any) {
-        this.messagesList = null
-        this.scanTime = null
+        this.clearFields()
         this.error = err.response?.data?.detail || err.message || 'An error occurred while starting the scan'
         if (err.response?.data?.detail[0]?.msg) {
           this.error = `${err.response?.data?.detail[0]?.input}: ${err.response?.data?.detail[0]?.msg}`
@@ -347,6 +346,11 @@ export default defineComponent({
           this.loading = false
         }
       }
+    },
+    clearFields() {
+      this.messagesList = null
+      this.scanTime = null
+      this.passed = false
     },
     parseResultsChecker(results_checker: string): ResultCheckerData {
       return JSON.parse(results_checker)


### PR DESCRIPTION
Resolve #130 

Add clearFields method and use it at the start of a scan. So the messageList is cleared and no old data is displayed.