### PR TITLE
fix: duplicate key 'networks'

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,8 +72,6 @@ services:
       - scanner
     depends_on:
       - valkey
-    networks:
-      - scanner
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://0.0.0.0:8082/api/v1/tests"]
       interval: 15s


### PR DESCRIPTION
failed to parse /srv/provider-online-check/docker-compose.prod.yml: yaml: construct errors:
  line 1: line 78: mapping key "networks" already defined at line 74

is based on concurrent edits (in different PRs):
ad111c10
8c2669c1