### PR TITLE
fix: normalize domains to lowercase

### DIFF
--- a/backend/src/validators/request_validator.py
+++ b/backend/src/validators/request_validator.py
@@ -8,13 +8,14 @@
 # Also checks if requested domain has a valid cache
 # in database -> handles cache lookup
 import re
+from urllib.parse import urlsplit, urlunsplit
 
 from ..database.valkey import Valkey_Controller
 
 # Basic domain validation pattern (same as before)
 DOMAIN_PATTERN = (
-    r"(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+"
-    r"[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+    r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+"
+    r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?"
 )
 
 REQUEST_PATTERN = (
@@ -23,11 +24,28 @@ REQUEST_PATTERN = (
 )
 
 
+def _normalize_hostname(hostname: str) -> str:
+    """Lowercase hostnames and convert them to Punycode"""
+    try:
+        # idna encoding returns bytes, then convert back to string
+        return hostname.lower().encode("idna").decode("ascii")
+    except (UnicodeError, UnicodeDecodeError):
+        return hostname.lower()
+
+
 def validate_domain(value: str) -> str:
     """
-    Validate and normalize a domain string.
+    Validate and normalize a scan target.
 
-    Returns the trimmed domain on success or raises ValueError on failure.
+    Normalizatios on the domain or PMD URL:
+    - Remove whitespace at start & end
+
+    Normalizations on the domain:
+    - Strip surrounding whitespace
+    - Lowercase the hostname and protocol scheme
+    - Convert IDN hostnames to Punycode
+
+    Returns the normalized domain on success or raises ValueError on failure.
     """
     if value is None:
         raise ValueError("Domain cannot be empty")
@@ -36,6 +54,14 @@ def validate_domain(value: str) -> str:
         raise ValueError("Domain cannot be empty")
 
     v = value.strip()
+    parts = urlsplit(v)
+
+    if parts.scheme:  # PMD URL
+        # the protocol scheme is lower-cased implicitly
+        v = urlunsplit(parts._replace(netloc=_normalize_hostname(parts.netloc)))
+    else:  # Domain
+        v = _normalize_hostname(v)
+
     if not re.match(REQUEST_PATTERN, v):
         raise ValueError(
             "Invalid domain/PMD format. Please enter a valid Domain or PMD URL. Domains require a non-zero length extension. PMDs must start with 'https://' and end with '/provider-metadata.json'"

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -367,6 +367,16 @@ class TestDomainValidation:
         with pytest.raises(ValueError, match="Invalid domain/PMD format. Please enter a valid Domain or PMD URL. Domains require a non-zero length extension. PMDs must start with 'https://' and end with '/provider-metadata.json'"):
             ScanRequest(domain="not a valid domain")
 
+    def test_validate_pmd_url_normalizes_hostname_only(self):
+        """validation lowercases PMD hostname but preserves path case"""
+        request = ScanRequest(session_id="0", domain="HTTPS://Example.COM/CSAF/provider-metadata.json")
+        assert request.domain == "https://example.com/CSAF/provider-metadata.json"
+
+    def test_validate_pmd_url_normalizes_idn_hostname(self):
+        """validation converts IDN hostname in PMD to Punycode"""
+        request = ScanRequest(session_id="0", domain="https://püñi.example/strange/path/provider-metadata.json")
+        assert request.domain == "https://xn--pi-zja7b.example/strange/path/provider-metadata.json"
+
 
 class TestOpenAPIDocumentation:
     """Tests for OpenAPI/Swagger documentation"""

--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -82,23 +82,26 @@ describe("Testing App...", () => {
         expect(app.vm.result?.status).toBe('RUNNING')
     })
     test('startScan CACHED_CHECKER', async () => {
+        app.vm.domain = "EXAMPLE.com"
         vi.spyOn(axios, 'post').mockImplementation(
             () => new Promise(resolve =>
             {
                 return resolve({
                     data: {
                         status: "CACHED_CHECKER",
+                        domain: "example.com",
                         results_checker: '{ "domains": [{ "requirements": [{ "messages": [{ "text": "Test1", "type": 0 }], "num": 12 }] }] }'
                     }
                 }
             )}
         ))
-        app.vm.domain = "Test"
         app.vm.startScan()
+        expect(app.vm.domainRescan).toBe('EXAMPLE.com')
         await flushPromises()
         expect(app.vm.loading).toBe(false)
         expect(app.vm.result?.status).toBe('CACHED_CHECKER')
         expect(app.vm.messagesList).toStrictEqual([{text: 'Test1', type: 0, num: 12}])
+        expect(app.vm.domainRescan).toBe('example.com')
 
     })
     test('startScan ERROR', async () => {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -375,6 +375,9 @@ export default defineComponent({
           session_id: this.session_id
         })
         this.result = response.data
+        if (this.result?.domain) {
+          this.domainRescan = this.result.domain
+        }
         if (['DONE_CHECKER', 'CACHED_CHECKER'].includes(this.result?.status)) {
           const parsedResultsChecker = this.parseResultsChecker(this.result.results_checker)
           this.extractMessagesFromResultsChecker(parsedResultsChecker)


### PR DESCRIPTION
a scan on example.com and EXAMPLE.com is the exact same
the same is not true for any upper case path components

also normalize punycode domains
before, IDNA domains were not allowed at all

in the frontend also show the normalized scan target as reported by the backend