### PR TITLE
Full Verbose Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Docker Compose reads this file automatically.
 | `PORT_BACKEND` | `48090` | Host port for the backend API. |
 | `PORT_FRONTEND` | `48091` | Host port for the frontend. |
 | `SCAN_SLOTS` | `10` | Maximum number of concurrent scans. |
-| `VERBOSE_OUTPUT_MAX_LINES_DEFAULT` | 10 | Default value for the maximum amount of verbose runtime output displayed at once. |
+| `VERBOSE_OUTPUT_MAX_LINES_DEFAULT` | 10 | Default value for the maximum amount of verbose runtime output displayed at once. Set to -1 for full logs |
 | `FOOTER_TEXT` | _empty_ | Custom HTML content appended to the footer of the frontend. |
 
 Example `.env`:

--- a/backend/docs/payload.md
+++ b/backend/docs/payload.md
@@ -22,6 +22,6 @@ Send from frontend to backend
 
         // Output Shortening
         start_at_line: int  // Earliest output entry to retrieve. Default: 0
-        max_lines: int      // Maximum lines to output. Set to 0 to get all lines. Default: 10
+        max_lines: int      // Maximum lines to output. Set to -1 to get all lines. Default: 10
         prioritize_newest_lines: bool // Output newest lines first. Default: True
     }

--- a/backend/docs/payload.md
+++ b/backend/docs/payload.md
@@ -22,6 +22,6 @@ Send from frontend to backend
 
         // Output Shortening
         start_at_line: int  // Earliest output entry to retrieve. Default: 0
-        max_lines: int      // Maximum entries to output. Default: 10
+        max_lines: int      // Maximum lines to output. Set to 0 to get all lines. Default: 10
         prioritize_newest_lines: bool // Output newest lines first. Default: True
     }

--- a/backend/src/router/router.py
+++ b/backend/src/router/router.py
@@ -107,10 +107,13 @@ async def start_scan(request: ScanRequest) -> ScanResponse:
         # Shorten output
         full_output = data.csaf_checker_output_runtime_log
         displayed_output = full_output
+        used_max_lines = request.max_lines
+        if used_max_lines == 0:
+            used_max_lines = len(full_output)  # Full logs
 
         if request.prioritize_newest_lines:
             # Latest max_lines entries. Lower boundary clamped at start_at_line
-            lower_boundary = max(0, len(full_output) - request.max_lines)
+            lower_boundary = max(0, len(full_output) - used_max_lines)
             if request.start_at_line > lower_boundary:
                 lower_boundary = request.start_at_line
 
@@ -118,7 +121,7 @@ async def start_scan(request: ScanRequest) -> ScanResponse:
         else:
             # max_lines entries starting from start_at_line
             # fmt: off
-            displayed_output = full_output[request.start_at_line:(request.start_at_line + request.max_lines)]  # Slicing is boundary safe
+            displayed_output = full_output[request.start_at_line:(request.start_at_line + used_max_lines)]  # Slicing is boundary safe
 
         return {
             "status": status,

--- a/backend/src/router/router.py
+++ b/backend/src/router/router.py
@@ -108,7 +108,7 @@ async def start_scan(request: ScanRequest) -> ScanResponse:
         full_output = data.csaf_checker_output_runtime_log
         displayed_output = full_output
         used_max_lines = request.max_lines
-        if used_max_lines == 0:
+        if used_max_lines == -1:
             used_max_lines = len(full_output)  # Full logs
 
         if request.prioritize_newest_lines:

--- a/backend/src/router/scan_request.py
+++ b/backend/src/router/scan_request.py
@@ -32,8 +32,8 @@ class ScanRequest(BaseModel):
     max_lines: Annotated[
         int,
         Field(
-            description="The maximum amount of runtime output lines that should be returned in the response. Set to 0 to get all lines",
-            ge=0,
+            description="The maximum amount of runtime output lines that should be returned in the response. Set to -1 to get all lines",
+            ge=-1,
         ),
     ] = int(os.environ.get("VERBOSE_OUTPUT_MAX_LINES_DEFAULT", "10"))
 

--- a/backend/src/router/scan_request.py
+++ b/backend/src/router/scan_request.py
@@ -32,7 +32,7 @@ class ScanRequest(BaseModel):
     max_lines: Annotated[
         int,
         Field(
-            description="The maximum amount of runtime output lines that should be returned in the response",
+            description="The maximum amount of runtime output lines that should be returned in the response. Set to 0 to get all lines",
             ge=0,
         ),
     ] = int(os.environ.get("VERBOSE_OUTPUT_MAX_LINES_DEFAULT", "10"))

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -338,6 +338,27 @@ class TestOutputOptions:
         assert shortResponse.status_code == 201
         assert len(shortResponseData["runtime_output"]) == 4
 
+    @pytest.mark.asyncio
+    async def test_max_lines_maximum(self):
+        await scan_example_domain()
+
+        """Max lines set to 0 should output all lines. Tests whether 0 is functionally the same as using max possible lines"""
+        minusOneResponse = client.post(
+            "/api/scan/start",
+            json=mock_scan_request_variable_shortening_options(0, 0, True)
+        )
+        minusOneData = minusOneResponse.json()
+
+        maxLinesResponse = client.post(
+            "/api/scan/start",
+            json=mock_scan_request_variable_shortening_options(0, 2147483647, True)
+        )
+        maxLinesData = maxLinesResponse.json()
+
+        assert minusOneResponse.status_code == 201
+        assert maxLinesResponse.status_code == 201
+        assert len(maxLinesData["runtime_output"]) == len(minusOneData["runtime_output"])
+
 
 class TestDomainValidation:
     """Tests for domain validation logic"""

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -342,10 +342,10 @@ class TestOutputOptions:
     async def test_max_lines_maximum(self):
         await scan_example_domain()
 
-        """Max lines set to 0 should output all lines. Tests whether 0 is functionally the same as using max possible lines"""
+        """Max lines set to -1 should output all lines. Tests whether -1 is functionally the same as using max possible lines"""
         minusOneResponse = client.post(
             "/api/scan/start",
-            json=mock_scan_request_variable_shortening_options(0, 0, True)
+            json=mock_scan_request_variable_shortening_options(0, -1, True)
         )
         minusOneData = minusOneResponse.json()
 


### PR DESCRIPTION
There is currently no option to retrieve all output logs. Although this can be circumvented by requesting an arbitrarily large number of `max_lines`, a cleaner version would be to represent a value (in this case `-1`) as a "show all logs" option