### PR TITLE
Adding memory limits to each container

### DIFF
--- a/.env
+++ b/.env
@@ -20,8 +20,11 @@ CSAF_SHA256=62995edf30703bed8c7fd2de4c5aec7692b47c8c66e5d8bdc04e6936b9185c60
 ## Scan Slots
 SCAN_SLOTS=10
 
-## Memory limit for the backend container (Docker memory string, e.g. 500m), 0 for unlimited
-CSAF_CHECKER_MEMORY_LIMIT=120m
+## Memory limit for the docker compose containers (Docker memory string, e.g. 500m), 0 for unlimited
+CSAF_CHECKER_MEMORY_LIMIT=500m
+FRONTEND_MEMORY_LIMIT=100m
+CSAF_VALIDATOR_MEMORY_LIMIT=75m
+VALKEY_MEMORY_LIMIT=500m
 
 ## Timeout for csaf_checker in seconds, 0 for unlimited
 CSAF_CHECKER_TIMEOUT=3600

--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ SCAN_SLOTS=10
 
 ## Memory limit for the docker compose containers (Docker memory string, e.g. 500m), 0 for unlimited
 CSAF_CHECKER_MEMORY_LIMIT=500m
-FRONTEND_MEMORY_LIMIT=100m
+FRONTEND_MEMORY_LIMIT=200m
 CSAF_VALIDATOR_MEMORY_LIMIT=75m
 VALKEY_MEMORY_LIMIT=500m
 

--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ SCAN_SLOTS=10
 
 ## Memory limit for the docker compose containers (Docker memory string, e.g. 500m), 0 for unlimited
 CSAF_CHECKER_MEMORY_LIMIT=500m
-FRONTEND_MEMORY_LIMIT=200m
+FRONTEND_MEMORY_LIMIT=400m
 CSAF_VALIDATOR_MEMORY_LIMIT=75m
 VALKEY_MEMORY_LIMIT=500m
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ Docker Compose reads this file automatically.
 | `PORT_BACKEND` | `48090` | Host port for the backend API. |
 | `PORT_FRONTEND` | `48091` | Host port for the frontend. |
 | `SCAN_SLOTS` | `10` | Maximum number of concurrent scans. |
-| `FRONTEND_MEMORY_LIMIT` | `100m` | Memory limit for the frontend container. |
+| `CSAF_CHECKER_MEMORY_LIMIT` | `500m` | Memory limit for the backend container. |
+| `FRONTEND_MEMORY_LIMIT` | `200m` | Memory limit for the frontend container. |
 | `CSAF_VALIDATOR_MEMORY_LIMIT` | `75m` | Memory limit for the validator container. |
 | `VALKEY_MEMORY_LIMIT` | `500m` | Memory limit for the valkey container. |
 | `VERBOSE_OUTPUT_MAX_LINES_DEFAULT` | 10 | Default value for the maximum amount of verbose runtime output displayed at once. |

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ Docker Compose reads this file automatically.
 | `PORT_BACKEND` | `48090` | Host port for the backend API. |
 | `PORT_FRONTEND` | `48091` | Host port for the frontend. |
 | `SCAN_SLOTS` | `10` | Maximum number of concurrent scans. |
+| `FRONTEND_MEMORY_LIMIT` | `100m` | Memory limit for the frontend container. |
+| `CSAF_VALIDATOR_MEMORY_LIMIT` | `75m` | Memory limit for the validator container. |
+| `VALKEY_MEMORY_LIMIT` | `500m` | Memory limit for the valkey container. |
 | `VERBOSE_OUTPUT_MAX_LINES_DEFAULT` | 10 | Default value for the maximum amount of verbose runtime output displayed at once. |
 | `FOOTER_TEXT` | _empty_ | Custom HTML content appended to the footer of the frontend. |
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Docker Compose reads this file automatically.
 | `RUNTIME_LOG_MAX_BYTES` | 500000 | Maximum total byte size of runtime log stored per scan, 0 for unlimited. |
 | `SCAN_SLOTS` | `10` | Maximum number of concurrent scans. |
 | `CSAF_CHECKER_MEMORY_LIMIT` | `500m` | Memory limit for the backend container. |
-| `FRONTEND_MEMORY_LIMIT` | `200m` | Memory limit for the frontend container. |
+| `FRONTEND_MEMORY_LIMIT` | `400m` | Memory limit for the frontend container. |
 | `CSAF_VALIDATOR_MEMORY_LIMIT` | `75m` | Memory limit for the validator container. |
 | `VALKEY_MEMORY_LIMIT` | `500m` | Memory limit for the valkey container. |
 | `VERBOSE_OUTPUT_MAX_LINES_DEFAULT` | 10 | Default value for the maximum amount of verbose runtime output displayed at once. |

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,6 +52,10 @@ services:
     ports:
       - "${PORT_FRONTEND:-48091}:8080"
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: ${FRONTEND_MEMORY_LIMIT:-100m}
     networks:
       - scanner
     depends_on:
@@ -73,6 +77,10 @@ services:
     ports:
       - "${PORT_VALIDATOR:-48092}:8082"
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: ${CSAF_VALIDATOR_MEMORY_LIMIT:-75m}
     networks:
       - scanner
     depends_on:
@@ -97,6 +105,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: ${VALKEY_MEMORY_LIMIT:-500m}
 
 volumes:
   valkey-data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,7 +55,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: ${FRONTEND_MEMORY_LIMIT:-100m}
+          memory: ${FRONTEND_MEMORY_LIMIT:-200m}
     networks:
       - scanner
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,7 +81,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: ${CSAF_VALIDATOR_MEMORY_LIMIT:-75m}
+          memory: ${CSAF_VALIDATOR_MEMORY_LIMIT:-150m}
     networks:
       - scanner
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -56,7 +56,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: ${FRONTEND_MEMORY_LIMIT:-200m}
+          memory: ${FRONTEND_MEMORY_LIMIT:-400m}
     networks:
       - scanner
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: ${FRONTEND_MEMORY_LIMIT:-100m}
+          memory: ${FRONTEND_MEMORY_LIMIT:-200m}
     networks:
       - scanner
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: ${FRONTEND_MEMORY_LIMIT:-200m}
+          memory: ${FRONTEND_MEMORY_LIMIT:-400m}
     networks:
       - scanner
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,10 @@ services:
       - VITE_FOOTER_TEXT=${FOOTER_TEXT:-}
       - VITE_BACKEND_PORT=${PORT_BACKEND:-443}
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: ${FRONTEND_MEMORY_LIMIT:-100m}
     networks:
       - scanner
     depends_on:
@@ -77,6 +81,10 @@ services:
     ports:
       - "${PORT_VALIDATOR:-48092}:8082"
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: ${CSAF_VALIDATOR_MEMORY_LIMIT:-75m}
     networks:
       - scanner
     depends_on:
@@ -98,6 +106,10 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: ${VALKEY_MEMORY_LIMIT:-500m}
 
 networks:
   scanner:


### PR DESCRIPTION
Only the backend container had a memory limit. This PR adds memory limits to frontend, validator and valkey. It also raises the default backend memory limit to `500m` to "survive" memory shots from sites like `cert.bund.de`

The memory limits are minimal requirements for normal execution plus a bit of a buffer.