### PR TITLE
feat: expanding: use triangle pattern

### DIFF
--- a/frontend/src/MessageGroup.spec.ts
+++ b/frontend/src/MessageGroup.spec.ts
@@ -32,7 +32,8 @@ describe('MessageGroup', () => {
             props: { num: 1, description: 'Test', messages: makeMessages(10) },
         })
         expect(wrapper.findAllComponents(MessageLine)).toHaveLength(5)
-        expect(wrapper.text()).toContain('5 more messages')
+        expect(wrapper.text()).toContain('show all 10 messages')
+        expect(wrapper.text()).toContain('...')
 
         await wrapper.find('.toggle-btn').trigger('click')
         // flush timers, then wait for Vue to re-render

--- a/frontend/src/MessageGroup.vue
+++ b/frontend/src/MessageGroup.vue
@@ -17,8 +17,10 @@ SPDX-License-Identifier: Apache-2.0
         v-if="messages.length > COLLAPSE_THRESHOLD"
         class="toggle-btn ms-2"
         @click="expanded ? collapse() : expand()"
-      >{{ expanded ? '▲ collapse' : '▼ show all' }}</button>
-      <span v-if="expanding" class="spinner-border spinner-border-sm ms-2" role="status" aria-hidden="true"></span>
+      >
+        <span v-if="expanding" class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+        {{ expanding ? (expanded ? 'collapse' : 'show all ' + messages.length + ' messages') : (expanded ? '▼ collapse' : '▶ show all ' + messages.length + ' messages') }}
+      </button>
     </div>
     <div class="message-group-body">
       <MessageLine
@@ -27,9 +29,10 @@ SPDX-License-Identifier: Apache-2.0
         :text="msg.text"
         :type="msg.type"
       />
-      <div v-if="!expanded && messages.length > COLLAPSE_THRESHOLD" class="show-more-hint text-muted">
+      <div v-if="messages.length > COLLAPSE_THRESHOLD" class="show-more-hint text-muted">
         <span v-if="expanding" class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-        <span v-else role="button" @click="expand" class="toggle-btn">{{ messages.length - COLLAPSE_THRESHOLD }} more message{{ messages.length - COLLAPSE_THRESHOLD !== 1 ? 's' : '' }}</span>
+        <span v-if="!expanded && !expanding" role="button" @click="expand" class="toggle-btn">...</span>
+        <span v-if="expanded && !expanding" role="button" @click="collapse" class="toggle-btn">collapse</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
right-pointing triangle for collapse, downward pointing for expanded replace triangle with spinner for loading state

show only ... at end of block if collapse, but keep the link add a collapse button at the end of the expanded block