### PR TITLE
fix: validator argument

### DIFF
--- a/backend/src/csaf/csaf_checker.py
+++ b/backend/src/csaf/csaf_checker.py
@@ -94,8 +94,7 @@ class CSAF_Checker(BaseModel):
         # Handle non-null running task
         await self.__terminate_asyncio_task()
 
-        # Write args. Everything after the `--` is not a flag but a positional argument (the scan target)
-        args = ["--verbose", "--", data.domain]
+        args = ["--verbose"]
 
         if data.enable_validator:
             args.append("--validator=http://validator:8082")
@@ -107,6 +106,10 @@ class CSAF_Checker(BaseModel):
                 args.append(
                     f"--validator_cache={CACHE_PATH_VALIDATOR}{data.validator_cache_file}"
                 )
+
+        # Write args. `--` before the domain ensures it is treated as a positional
+        # argument and not a flag, even if it starts with `-`.
+        args += ["--", data.domain]
 
         # Run task asynchronously
         self._running_task_checker = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
the -- argument separator worked perfectly, but the code was missing an adaption, leading to
```
2026/06/08 19:36:10 [GET]: https://--validator=http://validator:8082/.well-known/csaf/provider-metadata.json
```
etc.
so move the -- to the end of the arguments