### PR TITLE
fix: syntax in runtime output

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -157,9 +157,9 @@ SPDX-License-Identifier: Apache-2.0
                 <div v-if="result.runtime_output" class="mt-4">
                   <div :class="['alert', resultClass]" role="alert">
                     <h5 class="alert-heading">Details</h5>
-                    <li v-for="(item, index) in result.runtime_output" :key="index">
-                    <p class="mb-0">{{ item }}</p>
-                    </li>
+                    <ul>
+                      <li v-for="(item, index) in result.runtime_output" :key="index">{{ item }}</li>
+                    </ul>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
fix the HTML elements
missing `<ul>`, superfluous `<p>`

previous:
<img width="427" height="389" alt="image" src="https://github.com/user-attachments/assets/7aaaeb3f-572a-4d98-a5ff-5ad92730471a" />

now:
<img width="510" height="415" alt="image" src="https://github.com/user-attachments/assets/cab9391a-3f9e-48cf-a550-c5b0e626a64f" />