### PR TITLE
Add start_time and end_time to response and display duration

### DIFF
--- a/backend/src/router/router.py
+++ b/backend/src/router/router.py
@@ -131,6 +131,8 @@ async def start_scan(request: ScanRequest) -> ScanResponse:
             "results_checker": data.csaf_checker_output_result,
             "files_checked": data.files_checked,
             "latest_file_checked": data.latest_file_checked,
+            "start_time": data.start_time,
+            "end_time": data.end_time
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to start scan: {str(e)}")

--- a/backend/src/router/scan_response.py
+++ b/backend/src/router/scan_response.py
@@ -52,3 +52,15 @@ class ScanResponse(BaseModel):
             description="Name of the latest file that has been checked, including directory path"
         ),
     ] = ""
+    start_time: Annotated[
+        int,
+        Field(
+            description="Start time as timestamp"
+        )
+    ] = 0
+    end_time: Annotated[
+        int,
+        Field(
+            description="End time as timestamp"
+        )
+    ] = 0

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -61,8 +61,8 @@ SPDX-License-Identifier: Apache-2.0
                 </div>
 
                 <div v-show="scanTime">
-                  Start time of the check: {{ scanTime }}
-                  Duration {{ formatDuration(result?.start_time, result?.end_time) }}
+                  <div>Start time of the check: {{ scanTime }}</div>
+                  <div>Duration {{ formatDuration(result?.start_time, result?.end_time) }}</div>
                 </div>
 
                 <h4 :class="trustedProviderStatus" class="small-margin-top medium-font-size">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -544,16 +544,14 @@ export default defineComponent({
     },
     formatDuration(startTime: number, endTime: number) {
       const duration = endTime - startTime;
-      const hours = Math.floor(duration / 3600000);
-      const minutes = Math.floor((duration % 3600000) / 60000);
-      const seconds = Math.floor((duration % 60000) / 1000);
-      const milliseconds = duration % 1000;
+      const hours = Math.floor(duration / 3600);
+      const minutes = Math.floor((duration % 3600) / 60);
+      const seconds = Math.floor((duration % 60));
 
       return [
           hours && `${hours}h`,
           minutes && `${minutes}m`,
-          seconds && `${seconds}s`,
-          `${milliseconds}ms`
+          `${seconds}s`,
       ]
           .filter(Boolean)
           .join(' ');

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -39,9 +39,12 @@ SPDX-License-Identifier: Apache-2.0
               </form>
 
               <div class="alert alert-light mt-4" role="alert" v-show="domainRescan">
-                  {{ loading ? 'Running check on target': 'Completed the check of'}} <code>{{ domainRescan }}</code>
-                  <span v-if="loading" class="spinner-border spinner-border-sm ms-2" role="status" aria-hidden="true"></span>
-                  <span v-else class="ms-2">✓</span>
+                  <div>
+                    {{ loading ? 'Running check on target': 'Completed the check of'}} <code>{{ domainRescan }}</code>
+                    <span v-if="loading" class="spinner-border spinner-border-sm ms-2" role="status" aria-hidden="true"></span>
+                    <span v-else class="ms-2">✓</span>
+                  </div>
+                  <div>Duration {{ formatDuration(result?.start_time, result?.end_time) }}</div>
               </div>
 
               <!-- display of requirements messages -->
@@ -62,7 +65,6 @@ SPDX-License-Identifier: Apache-2.0
 
                 <div v-show="scanTime">
                   <div>Start time of the check: {{ scanTime }}</div>
-                  <div>Duration {{ formatDuration(result?.start_time, result?.end_time) }}</div>
                 </div>
 
                 <h4 :class="trustedProviderStatus" class="small-margin-top medium-font-size">
@@ -543,6 +545,9 @@ export default defineComponent({
       return new Date(ts * 1000).toLocaleString()
     },
     formatDuration(startTime: number, endTime: number) {
+      if (endTime === 0) {
+        endTime = Date.now() / 1000
+      }
       const duration = endTime - startTime;
       const hours = Math.floor(duration / 3600);
       const minutes = Math.floor((duration % 3600) / 60);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -62,6 +62,7 @@ SPDX-License-Identifier: Apache-2.0
 
                 <div v-show="scanTime">
                   Start time of the check: {{ scanTime }}
+                  Duration {{ formatDuration(result?.start_time, result?.end_time) }}
                 </div>
 
                 <h4 :class="trustedProviderStatus" class="small-margin-top medium-font-size">
@@ -540,6 +541,22 @@ export default defineComponent({
     },
     formatTime(ts: number) {
       return new Date(ts * 1000).toLocaleString()
+    },
+    formatDuration(startTime: number, endTime: number) {
+      const duration = endTime - startTime;
+      const hours = Math.floor(duration / 3600000);
+      const minutes = Math.floor((duration % 3600000) / 60000);
+      const seconds = Math.floor((duration % 60000) / 1000);
+      const milliseconds = duration % 1000;
+
+      return [
+          hours && `${hours}h`,
+          minutes && `${minutes}m`,
+          seconds && `${seconds}s`,
+          `${milliseconds}ms`
+      ]
+          .filter(Boolean)
+          .join(' ');
     }
   }
 })


### PR DESCRIPTION
Resolve #100 

In Domain Task Data a start_time and an end_time exist. Provide them to the frontend.
Add a formatDuration method and display the duration near the scan time. 