### PR TITLE
Set error to null at begin of a new scan

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -398,6 +398,7 @@ export default defineComponent({
     },
     async scanWork() {
       try {
+        this.error = null
         const response = await axios.post(`${this.backendUrl}/api/scan/start`, {
           domain: this.domain,
           session_id: this.session_id
@@ -420,6 +421,7 @@ export default defineComponent({
         }
       } catch (err: any) {
         this.clearFields()
+        this.result = null
         this.error = err.response?.data?.detail || err.message || 'An error occurred while starting the scan'
         if (err.response?.data?.detail[0]?.msg) {
           this.error = `${err.response?.data?.detail[0]?.input}: ${err.response?.data?.detail[0]?.msg}`

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -440,6 +440,7 @@ export default defineComponent({
       this.loading = false
       this.allowInput = true
       this.result = null
+      this.error = null
       this.clearFields()
     },
     clearFields() {


### PR DESCRIPTION
Resolve #189 

Also clear result at a thrown exception.
If an exception is thrown, the result field contains old data. So I clear it in this case.
At a start of scan, no error has happened, so clear old errors.  