### PR TITLE
fix: set default CSAF_REF to empty string and bump version

### DIFF
--- a/.env
+++ b/.env
@@ -20,7 +20,7 @@ CSAF_SHA256=62995edf30703bed8c7fd2de4c5aec7692b47c8c66e5d8bdc04e6936b9185c60
 ## gocsaf source build
 ## Set to a branch name, tag, or commit SHA to build csaf_checker from source
 ## Requires at least 400m memory in the backend container (env CSAF_CHECKER_MEMORY_LIMIT)
-# CSAF_REF=main
+CSAF_REF=
 
 ## Scan Slots
 SCAN_SLOTS=10

--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ PORT_VALIDATOR=48092
 ## Component Version
 CSAF_CHECKER_VERSION=3.5.1
 CSAF_VALIDATOR_VERSION=2.0.25
-APP_VERSION=0.2.0
+APP_VERSION=0.3.0
 # The expected checksum of the gocsaf tarball, used in production builds for verification
 CSAF_SHA256=62995edf30703bed8c7fd2de4c5aec7692b47c8c66e5d8bdc04e6936b9185c60
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ npm run coverage-single
 The version number must adhere to [semantic versioning 2.0.0](https://semver.org/).
 
 * In `.env` set `APP_VERSION` to the new release version
-* In `frontend/package.json` set the version (line 3) to the new release version
+* In `frontend/package.json` (line 3) and `frontend/package-lock.json` (lines 3 and 9) set the version  to the new release version
 * Commit
 * Make a Pull Request, request reviews
 * Merge into branch `main`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csaf-provider-scan-frontend",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csaf-provider-scan-frontend",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "axios": "^1.6.0",
         "bootstrap": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csaf-provider-scan-frontend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CSAF Provider Scan Frontend",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
fix: set default CSAF_REF to empty string

to prevent this warning:
WARN[0000] The "CSAF_REF" variable is not set. Defaulting to a blank string.

rel: bump version to 0.3.0
and also change the version numbers in package-lock.json