### PR TITLE
fix: generate images for sboms from compose and with consistent name

### DIFF
--- a/dev/sboms/generate-sboms.sh
+++ b/dev/sboms/generate-sboms.sh
@@ -30,6 +30,11 @@ fi
 IMAGE_TAG_SYFT="syft-sboms-image"
 CONTAINER_NAME_SYFT="syft-sboms-active-container"
 
+# Read settings from environment variable file
+set -a
+. "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/.env"
+set +a
+
 IMAGE_TAG_BACKEND="csaf-provider-online-check-backend"
 IMAGE_TAG_FRONTEND="csaf-provider-online-check-frontend"
 IMAGE_TAG_VALIDATOR="csaf-provider-online-check-validator"
@@ -37,9 +42,9 @@ IMAGE_TAG_VALKEY="valkey/valkey:8-alpine"
 
 # Build Images
 docker build -t "$IMAGE_TAG_SYFT" ./dev/sboms/
-docker compose build backend
-docker compose build frontend
-docker compose build validator
+docker build -t "$IMAGE_TAG_BACKEND" --build-arg "CSAF_SHA256=${CSAF_SHA256}" --build-arg "CSAF_CHECKER_VERSION=${CSAF_CHECKER_VERSION}" ./backend/
+docker build -t "$IMAGE_TAG_FRONTEND" ./frontend/
+docker build -t "$IMAGE_TAG_VALIDATOR" --build-arg "CSAF_VALIDATOR_VERSION=${CSAF_VALIDATOR_VERSION}" ./validator/
 
 # Run Syft container
 cleanup()

--- a/dev/sboms/generate-sboms.sh
+++ b/dev/sboms/generate-sboms.sh
@@ -37,9 +37,9 @@ IMAGE_TAG_VALKEY="valkey/valkey:8-alpine"
 
 # Build Images
 docker build -t "$IMAGE_TAG_SYFT" ./dev/sboms/
-docker build -t "$IMAGE_TAG_BACKEND" ./backend/
-docker build -t "$IMAGE_TAG_FRONTEND" ./frontend/
-docker build -t "$IMAGE_TAG_VALIDATOR" ./validator/
+docker compose build backend
+docker compose build frontend
+docker compose build validator
 
 # Run Syft container
 cleanup()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+name: csaf-provider-online-check
 services:
   backend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+name: csaf-provider-online-check
 services:
   backend:
     build:


### PR DESCRIPTION
SBOM generation failed because for building the backend containers we need .env to be loaded, which `docker build` does not do. so switch to `docker compose build`, which is in sync to the other tools and uses `.env`
for consistent naming of the docker images, set a project name, so it does not depend on the parent directory's name