### PR TITLE
Use the evaluation trail and show only relevant requirements

### DIFF
--- a/.env
+++ b/.env
@@ -20,7 +20,7 @@ CSAF_SHA256=62995edf30703bed8c7fd2de4c5aec7692b47c8c66e5d8bdc04e6936b9185c60
 ## gocsaf source build
 ## Set to a branch name, tag, or commit SHA to build csaf_checker from source
 ## Requires at least 400m memory in the backend container (env BACKEND_MEMORY_LIMIT)
-CSAF_REF=34b7d18
+CSAF_REF=f048ad9
 
 ## Scan Slots
 SCAN_SLOTS=10

--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -164,65 +164,50 @@ describe("Testing App...", () => {
         ])
         expect(app.vm.filterMessageListByNums([4])).toStrictEqual([])
     })
-    test('trustedProviderMessages with one message', () => {
-        app.vm.messagesList = [{ text: "Test1", type: 0, num: 1}]
-        expect(app.vm.trustedProviderMessages).toStrictEqual([
-            { text: "Test1", type: 0, num: 1}
-        ])
-    })
-    test('trustedProviderMessages req 8-10', () => {
-        app.vm.messagesList = [
-            { text: "Test8", type: 0, num: 8 },
-            { text: "Test9", type: 2, num: 9 },
-            { text: "Test10", type: 2, num: 10 }
-        ]
-        expect(app.vm.trustedProviderMessages).toStrictEqual([
-            { text: "Test8", type: 0, num: 8 }
-        ])
-        app.vm.messagesList = [
-            { text: "Test8", type: 2, num: 8 },
-            { text: "Test9", type: 0, num: 9 },
-            { text: "Test10", type: 2, num: 10 }
-        ]
-        expect(app.vm.trustedProviderMessages).toStrictEqual([
-            { text: "Test9", type: 0, num: 9 }
-        ])
-        app.vm.messagesList = [
-            { text: "Test8", type: 2, num: 8 },
-            { text: "Test9", type: 2, num: 9 },
-            { text: "Test10", type: 0, num: 10 }
-        ]
-        expect(app.vm.trustedProviderMessages).toStrictEqual([
-            { text: "Test10", type: 0, num: 10 }
-        ])
-        app.vm.messagesList = [
-            { text: "Test8", type: 2, num: 8 },
-            { text: "Test9", type: 2, num: 9 },
-            { text: "Test10", type: 2, num: 10 }
-        ]
-        expect(app.vm.trustedProviderMessages).toStrictEqual([
-            { text: "Test8", type: 2, num: 8 },
-            { text: "Test9", type: 2, num: 9 },
-            { text: "Test10", type: 2, num: 10 }
-        ])
-    })
-    test("trustedProviderMessages dir-based vs ROLIE", () => {
-        app.vm.messagesList = [
-            { text: "Test11", type: 0, num: 11 },
-            { text: "Test15", type: 2, num: 15 }
-        ]
-        expect(app.vm.trustedProviderMessages).toStrictEqual([
-            { text: "Test11", type: 0, num: 11 }
-        ])
-        app.vm.messagesList = [
-            { text: "Test11", type: 2, num: 11 },
-            { text: "Test15", type: 0, num: 15 }
-        ]
-        expect(app.vm.trustedProviderMessages).toStrictEqual([
-            { text: "Test15", type: 0, num: 15 }
-        ])
-        app.vm.messagesList = null;
+    test('trustedProviderMessages: null messagesList returns null', () => {
+        app.vm.messagesList = null
         expect(app.vm.trustedProviderMessages).toBe(null)
+    })
+    test('trustedProviderMessages: no evaluated_rules trail returns full messagesList', () => {
+        app.vm.messagesList = [{ text: "Test1", type: 0, num: 1 }]
+        app.vm.relevantRequirementNums = null
+        expect(app.vm.trustedProviderMessages).toStrictEqual([{ text: "Test1", type: 0, num: 1 }])
+    })
+    test('trustedProviderMessages: filters to relevantRequirementNums from trail', () => {
+        app.vm.messagesList = [
+            { text: "msg8", type: 0, num: 8 },
+            { text: "msg9", type: 2, num: 9 },
+            { text: "msg15", type: 0, num: 15 },
+        ]
+        app.vm.relevantRequirementNums = [8, 15]
+        expect(app.vm.trustedProviderMessages).toStrictEqual([
+            { text: "msg8", type: 0, num: 8 },
+            { text: "msg15", type: 0, num: 15 },
+        ])
+    })
+    test('extractMessagesFromResultsChecker: sets relevantRequirementNums from evaluated_rules', () => {
+        app.vm.extractMessagesFromResultsChecker({
+            date: '2026-06-26T00:00:00Z',
+            domains: [{
+                passed: true,
+                role: 'csaf_trusted_provider',
+                requirements: [
+                    { num: 8, description: 'security.txt', messages: [{ text: 'ok', type: 0 }] },
+                    { num: 9, description: '/.well-known/csaf/provider-metadata.json', messages: [{ text: 'ok', type: 0 }] },
+                ],
+                evaluated_rules: {
+                    condition: 'one',
+                    includes: [
+                        { condition: 'all', requirement: 8, passed: true },
+                        { condition: 'all', requirement: 9, passed: false },
+                    ]
+                }
+            }]
+        })
+        expect(app.vm.relevantRequirementNums).toStrictEqual([8])
+        expect(app.vm.trustedProviderMessages).toStrictEqual([
+            { text: 'ok', type: 0, num: 8 }
+        ])
     })
     test("groupedTrustedProviderMessages groups messages by requirement", () => {
         app.vm.requirementGroups = [

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -352,11 +352,10 @@ export default defineComponent({
     footerText() {
       return import.meta.env.VITE_FOOTER_TEXT || ''
     },
-    trustedProviderMessages() {
-      const self = this as any  // FIXME
-      if (!self.messagesList) return null
-      if (!self.relevantRequirementNums) return self.messagesList
-      return self.filterMessageListByNums(self.relevantRequirementNums)
+    trustedProviderMessages(): null | MessageData[] {
+      if (!this.messagesList) return null
+      if (!this.relevantRequirementNums) return this.messagesList
+      return this.filterMessageListByNums(this.relevantRequirementNums)
     },
     groupedTrustedProviderMessages(): RequirementGroup[] {
       const flatMessages = this.trustedProviderMessages

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -84,6 +84,7 @@ SPDX-License-Identifier: Apache-2.0
                   :num="group.num"
                   :description="group.description"
                   :messages="group.messages"
+                  :passed="group.passed"
                 />
 
                 <p class="small-margin-top">
@@ -234,13 +235,15 @@ import axios from 'axios'
 import { defineComponent } from 'vue'
 import MessageLine from './MessageLine.vue'
 import MessageGroup from './MessageGroup.vue'
-import VersionDisplay from './VersionDisplay.vue';
+import VersionDisplay from './VersionDisplay.vue'
+import { relevantRequirements, type EvaluatedRule } from './evaluatedRules'
 
 interface ResultCheckerData {
   domains: {
     requirements: {num: number, description: string, messages: {text: string, type: number}[]}[],
     passed: boolean;
     role: string;
+    evaluated_rules?: EvaluatedRule;
   }[];
   date: string;
 }
@@ -249,6 +252,7 @@ interface RequirementGroup {
   num: number;
   description: string;
   messages: { text: string; type: number }[];
+  passed: boolean;
 }
 
 interface AppData {
@@ -260,6 +264,7 @@ interface AppData {
   error: any;
   messagesList: null | MessageData[];
   requirementGroups: RequirementGroup[];
+  relevantRequirementNums: number[] | null;
   scanTime: null | string;
   passed: boolean;
   role: string | null;
@@ -295,6 +300,7 @@ export default defineComponent({
       error: null,
       messagesList: null,
       requirementGroups: [],
+      relevantRequirementNums: null,
       scanTime: null,
       passed: false,
       role: null,
@@ -347,62 +353,23 @@ export default defineComponent({
       return import.meta.env.VITE_FOOTER_TEXT || ''
     },
     trustedProviderMessages() {
-      if (this.messagesList) {
-        const trustedProviderMessages = []
-
-        // requirements 1 (Valid CSAF document), 2 (Filename), 3 (TLS), 4 (TLP:WHITE)
-        // Show all messages
-        trustedProviderMessages.push(...this.filterMessageListByNums([1, 2, 3, 4]))
-
-        // requirements 5 (TLP:AMBER and TLP:RED), 6 (Redirects) and 7 (provider-metadata.json)
-        // Show all messages
-        trustedProviderMessages.push(...this.filterMessageListByNums([5, 6, 7]))
-
-        // requirements min one of 8 (security.txt), 9 (Well-known URL for provider-metadata.json), 10 (DNS path)
-        // One must succeed, then show that message, else show all messages
-        const req8Messages = this.filterMessageListByNums([8])
-        const req9Messages = this.filterMessageListByNums([9])
-        const req10Messages = this.filterMessageListByNums([10])
-        if (req8Messages.length > 0  && req8Messages.filter((msg:MessageData) => msg.type === 2).length === 0) {
-          trustedProviderMessages.push(...req8Messages)
-        } else if (req9Messages.length > 0  && req9Messages.filter((msg:MessageData) => msg.type === 2).length === 0) {
-          trustedProviderMessages.push(...req9Messages)
-        } else if (req10Messages.length > 0  && req10Messages.filter((msg:MessageData) => msg.type === 2).length === 0) {
-          trustedProviderMessages.push(...req10Messages)
-        } else {
-          trustedProviderMessages.push(...req8Messages, ...req9Messages, ...req10Messages)
-        }
-
-        // requirements dir based 11 (One folder per year), 12 (index.txt), 13 (changes.csv), 14 (Directory listings)
-        //           or ROLIE based 15 (ROLIE feed), 16 (ROLIE service document), 17 (ROLIE category document)
-        // Show the dir-based messages or show the ROLIE based messages
-        const dirBaseMessages = this.filterMessageListByNums([11, 12, 13, 14])
-        const rolieBaseMessages = this.filterMessageListByNums([15, 16, 17])
-        if (rolieBaseMessages.filter((msg:MessageData) => msg.type === 2).length
-            <= dirBaseMessages.filter((msg: MessageData) => msg.type === 2).length) {
-          trustedProviderMessages.push(...rolieBaseMessages)
-        } else {
-          trustedProviderMessages.push(...dirBaseMessages)
-        }
-
-        // requirements 18 (Integrity), 19 (Signatures), 20 (Public OpenPGP Key)
-        // Show all messages
-        trustedProviderMessages.push(...this.filterMessageListByNums([18, 19, 20]))
-        return trustedProviderMessages
-      }
-      return null
+      const self = this as any  // FIXME
+      if (!self.messagesList) return null
+      if (!self.relevantRequirementNums) return self.messagesList
+      return self.filterMessageListByNums(self.relevantRequirementNums)
     },
     groupedTrustedProviderMessages(): RequirementGroup[] {
       const flatMessages = this.trustedProviderMessages
       if (!flatMessages) return []
       const groupMap = new Map<number, RequirementGroup>()
       for (const g of this.requirementGroups) {
-        groupMap.set(g.num, { num: g.num, description: g.description, messages: [] })
+        groupMap.set(g.num, { num: g.num, description: g.description, messages: [], passed: true })
       }
       for (const msg of flatMessages) {
         const group = groupMap.get(msg.num)
         if (group) {
           group.messages.push({ text: msg.text, type: msg.type })
+          if (msg.type === 2) group.passed = false
         }
       }
       return [...groupMap.values()].filter(g => g.messages.length > 0)
@@ -482,6 +449,7 @@ export default defineComponent({
     clearFields() {
       this.messagesList = null
       this.requirementGroups = []
+      this.relevantRequirementNums = null
       this.scanTime = null
       this.passed = false
       this.isShowAllMessages = false
@@ -532,8 +500,13 @@ export default defineComponent({
       logOutputRef?.addEventListener('shown.bs.collapse', () => { logOutputRef.scrollIntoView({ behavior: 'smooth', block: 'nearest' }) })
     },
     extractMessagesFromResultsChecker(results_checker: ResultCheckerData) {
-      if (results_checker.domains?.[0]?.requirements) {
-        this.extractMessages(results_checker.domains[0].requirements)
+      const domain = results_checker.domains?.[0]
+      if (domain?.requirements) {
+        this.extractMessages(domain.requirements)
+        const evaluatedRules = domain.evaluated_rules
+        if (evaluatedRules) {
+          this.relevantRequirementNums = relevantRequirements(evaluatedRules)
+        }
       } else {
         this.messagesList = null
       }

--- a/frontend/src/MessageGroup.spec.ts
+++ b/frontend/src/MessageGroup.spec.ts
@@ -14,14 +14,14 @@ const makeMessages = (n: number) =>
 describe('MessageGroup', () => {
     test('renders requirement header', () => {
         const wrapper = mount(MessageGroup, {
-            props: { num: 15, description: 'ROLIE feed', messages: makeMessages(2) },
+            props: { num: 15, description: 'ROLIE feed', messages: makeMessages(2), passed: true },
         })
         expect(wrapper.text()).toContain('ROLIE feed')
     })
 
     test('shows all messages when count <= threshold', () => {
         const wrapper = mount(MessageGroup, {
-            props: { num: 1, description: 'Test', messages: makeMessages(5) },
+            props: { num: 1, description: 'Test', messages: makeMessages(5), passed: false },
         })
         expect(wrapper.findAllComponents(MessageLine)).toHaveLength(5)
         expect(wrapper.text()).not.toContain('more message')
@@ -29,7 +29,7 @@ describe('MessageGroup', () => {
 
     test('truncates to 5, expands and collapses', async () => {
         const wrapper = mount(MessageGroup, {
-            props: { num: 1, description: 'Test', messages: makeMessages(10) },
+            props: { num: 1, description: 'Test', messages: makeMessages(10), passed: true },
         })
         expect(wrapper.findAllComponents(MessageLine)).toHaveLength(5)
         expect(wrapper.text()).toContain('show all 10 messages')
@@ -55,7 +55,7 @@ describe('MessageGroup', () => {
             { text: 'c', type: 2 },
         ]
         const wrapper = mount(MessageGroup, {
-            props: { num: 1, description: 'Test', messages },
+            props: { num: 1, description: 'Test', messages, passed: true },
         })
         expect(wrapper.text()).toContain('1 error')
         expect(wrapper.text()).toContain('1 warning')

--- a/frontend/src/MessageGroup.vue
+++ b/frontend/src/MessageGroup.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <div class="message-group small-margin-top">
+  <div class="message-group small-margin-top" :class="passed ? 'group-passed' : 'group-failed'">
     <div class="message-group-header">
       <span class="requirement-desc">{{ description }}</span>
       <span v-if="messages.length > 0" class="message-counts ms-2">
@@ -51,6 +51,7 @@ export default defineComponent({
     num: { type: Number, required: true },
     description: { type: String, required: true },
     messages: { type: Array as () => { text: string; type: number }[], required: true },
+    passed: { type: Boolean, required: true },
   },
   data() {
     return {
@@ -117,5 +118,11 @@ export default defineComponent({
 }
 .toggle-btn:hover {
   text-decoration: underline;
+}
+.group-failed {
+  background-color: lightyellow;
+}
+.group-passed {
+  background-color: #90ee9024;
 }
 </style>

--- a/frontend/src/evaluatedRules.spec.ts
+++ b/frontend/src/evaluatedRules.spec.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest'
+import { relevantRequirements, type EvaluatedRule } from './evaluatedRules'
+import intevation from '../tests/assets/intevation.de-result.json'
+import innomic from '../tests/assets/www.innomic.com-result.json'
+import isduba from '../tests/assets/isduba.github.io-result.json'
+import exampleCom from '../tests/assets/example.com-result.json'
+
+describe('relevantRequirements', () => {
+  test('leaf node: passed true returns requirement number', () => {
+    let rule: EvaluatedRule = { condition: 'all', requirement: 3, passed: true }
+    expect(relevantRequirements(rule)).toStrictEqual([3])
+    rule.condition = 'one'
+    expect(relevantRequirements(rule)).toStrictEqual([3])
+  })
+
+  test('leaf node: passed false returns requirement number', () => {
+    let rule: EvaluatedRule = { condition: 'all', requirement: 5, passed: false }
+    expect(relevantRequirements(rule)).toStrictEqual([5])
+    rule.condition = 'one'
+    expect(relevantRequirements(rule)).toStrictEqual([5])
+  })
+
+  test('condition all: returns all requirement numbers regardless of passed', () => {
+    const rule: EvaluatedRule = {
+      condition: 'all',
+      includes: [
+        { condition: 'all', requirement: 1, passed: true },
+        { condition: 'all', requirement: 2, passed: false },
+        { condition: 'all', requirement: 3, passed: true },
+      ]
+    }
+    expect(relevantRequirements(rule)).toStrictEqual([1, 2, 3])
+  })
+
+  test('condition one: returns only the first passing branch', () => {
+    const rule: EvaluatedRule = {
+      condition: 'one',
+      includes: [
+        { condition: 'all', requirement: 8, passed: false },
+        { condition: 'all', requirement: 9, passed: true },
+        { condition: 'all', requirement: 10, passed: false },
+      ]
+    }
+    expect(relevantRequirements(rule)).toStrictEqual([9])
+  })
+
+  test('condition one: picks first branch when multiple pass', () => {
+    const rule: EvaluatedRule = {
+      condition: 'one',
+      includes: [
+        { condition: 'all', requirement: 8, passed: true },
+        { condition: 'all', requirement: 9, passed: true },
+        { condition: 'all', requirement: 10, passed: false },
+      ]
+    }
+    expect(relevantRequirements(rule)).toStrictEqual([8])
+  })
+
+  test('condition one: returns all branches when none pass', () => {
+    const rule: EvaluatedRule = {
+      condition: 'one',
+      includes: [
+        { condition: 'all', requirement: 8, passed: false },
+        { condition: 'all', requirement: 9, passed: false },
+        { condition: 'all', requirement: 10, passed: false },
+      ]
+    }
+    expect(relevantRequirements(rule)).toStrictEqual([8, 9, 10])
+  })
+
+  test('condition one: multi-leaf branch must have all leaves passing to count as passed', () => {
+    const rule: EvaluatedRule = {
+      condition: 'one',
+      includes: [
+        {
+          condition: 'all',
+          includes: [
+            { condition: 'all', requirement: 11, passed: true },
+            { condition: 'all', requirement: 12, passed: false }, // whole branch fails
+          ]
+        },
+        {
+          condition: 'all',
+          includes: [
+            { condition: 'all', requirement: 15, passed: true },
+            { condition: 'all', requirement: 16, passed: true },
+          ]
+        },
+      ]
+    }
+    expect(relevantRequirements(rule)).toStrictEqual([15, 16])
+  })
+
+  test('example.com: no evaluated_rules when target is not a CSAF provider', () => {
+      expect((exampleCom.domains[0] as any).evaluated_rules).toBeUndefined()
+    })
+
+  test('intevation.de trail: req 8 wins, ROLIE wins -> [1-8,15-20]', () => {
+    const rule = intevation.domains[0].evaluated_rules as EvaluatedRule
+    expect(relevantRequirements(rule)).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 15, 16, 17, 18, 19, 20])
+  })
+
+  test('www.innomic.com trail: req 8 wins, dir-based wins -> [1-8,11-14]', () => {
+    const rule = innomic.domains[0].evaluated_rules as EvaluatedRule
+    expect(relevantRequirements(rule)).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14])
+  })
+
+  test('isduba.github.io trail: req 9 wins, ROLIE wins -> [1-7,9,15-20], 8 fails -> overall fail', () => {
+    const rule = isduba.domains[0].evaluated_rules as EvaluatedRule
+    expect(relevantRequirements(rule)).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 9, 15, 16, 17, 18, 19, 20])
+  })
+})

--- a/frontend/src/evaluatedRules.spec.ts
+++ b/frontend/src/evaluatedRules.spec.ts
@@ -12,14 +12,14 @@ import exampleCom from '../tests/assets/example.com-result.json'
 
 describe('relevantRequirements', () => {
   test('leaf node: passed true returns requirement number', () => {
-    let rule: EvaluatedRule = { condition: 'all', requirement: 3, passed: true }
+    const rule: EvaluatedRule = { condition: 'all', requirement: 3, passed: true }
     expect(relevantRequirements(rule)).toStrictEqual([3])
     rule.condition = 'one'
     expect(relevantRequirements(rule)).toStrictEqual([3])
   })
 
   test('leaf node: passed false returns requirement number', () => {
-    let rule: EvaluatedRule = { condition: 'all', requirement: 5, passed: false }
+    const rule: EvaluatedRule = { condition: 'all', requirement: 5, passed: false }
     expect(relevantRequirements(rule)).toStrictEqual([5])
     rule.condition = 'one'
     expect(relevantRequirements(rule)).toStrictEqual([5])

--- a/frontend/src/evaluatedRules.ts
+++ b/frontend/src/evaluatedRules.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export interface EvaluatedRule {
+  condition: 'all' | 'one'
+  requirement?: number
+  passed?: boolean
+  includes?: EvaluatedRule[]
+}
+
+function branchPassed(rule: EvaluatedRule): boolean {
+  // checks recursively if the branch has passed == true
+  if (rule.requirement) {
+    return rule.passed === true
+  }
+  if (rule.condition === 'all') {
+    return (rule.includes ?? []).every(branchPassed)
+  }
+  return (rule.includes ?? []).some(branchPassed)
+}
+
+export function relevantRequirements(rule: EvaluatedRule): number[] {
+  // returns all the relevant requirements that have lead to the overall passed-result
+  if (rule.requirement) {
+    return [rule.requirement]
+  }
+
+  if (rule.condition === 'all') {
+    // include all the requirements under this rule, regardless of their passed-status
+    return (rule.includes ?? []).flatMap(relevantRequirements)
+  }
+
+  if (rule.condition === 'one') {
+    // condition 'one': show the first branch that passed
+    const winner = (rule.includes ?? []).find(branchPassed)
+    if (winner) {
+      return relevantRequirements(winner)
+    }
+    // else: return all, see below
+  }
+
+  // no conditition passed: show all branches so the users see what failed
+  return (rule.includes ?? []).flatMap(relevantRequirements)
+}

--- a/frontend/tests/assets/example.com-result.json
+++ b/frontend/tests/assets/example.com-result.json
@@ -1,0 +1,38 @@
+{
+  "domains": [
+    {
+      "name": "example.com",
+      "requirements": [
+        {
+          "num": 0,
+          "description": "Invalid provider metadata",
+          "messages": [
+            {
+              "type": 1,
+              "text": "Unexpected situation while loading provider-metadata.json: fetching \"https://example.com/.well-known/csaf/provider-metadata.json\" failed: 404 Not Found (404)"
+            },
+            {
+              "type": 1,
+              "text": "Unexpected situation while loading provider-metadata.json: Fetching \"https://example.com/.well-known/security.txt\" failed: 404 Not Found (404)"
+            },
+            {
+              "type": 1,
+              "text": "Unexpected situation while loading provider-metadata.json: Fetching \"https://example.com/security.txt\" failed: 404 Not Found (404)"
+            },
+            {
+              "type": 1,
+              "text": "Unexpected situation while loading provider-metadata.json: fetching \"https://csaf.data.security.example.com\" failed: Get \"https://csaf.data.security.example.com\": dial tcp: lookup csaf.data.security.example.com on 127.0.0.11:53: no such host"
+            },
+            {
+              "type": 2,
+              "text": "Could not parse the Provider-Metadata.json of: example.com"
+            }
+          ]
+        }
+      ],
+      "passed": false
+    }
+  ],
+  "version": "3.5.2-57-gf048ad9",
+  "date": "2026-06-30T07:43:21.08348165Z"
+}

--- a/frontend/tests/assets/example.com-result.json.license
+++ b/frontend/tests/assets/example.com-result.json.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2026 SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+SPDX-License-Identifier: Apache-2.0

--- a/frontend/tests/assets/intevation.de-result.json
+++ b/frontend/tests/assets/intevation.de-result.json
@@ -1,0 +1,376 @@
+{
+  "domains": [
+    {
+      "name": "intevation.de",
+      "publisher": {
+        "category": "vendor",
+        "name": "Intevation GmbH",
+        "namespace": "https://intevation.de",
+        "contact_details": "mailto:security@intevation.de, encryption via OpenPGP: https://intevation.de/.well-known/openpgpkey/hu/t5s8ztdbon8yzntexy6oz5y48etqsnbb"
+      },
+      "role": "csaf_trusted_provider",
+      "requirements": [
+        {
+          "num": 1,
+          "description": "Valid CSAF documents",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All advisories validated fine."
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "description": "Filename",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All found filenames are conforming."
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "description": "TLS",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All tested URLs were HTTPS."
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "description": "TLP:WHITE",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All advisories labeled TLP:WHITE were freely accessible."
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "description": "TLP:AMBER and TLP:RED",
+          "messages": [
+            {
+              "type": 0,
+              "text": "No advisories labeled TLP:AMBER or TLP:RED tested for accessibility."
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "description": "Redirects",
+          "messages": [
+            {
+              "type": 0,
+              "text": "No redirections found."
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "description": "provider-metadata.json",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found good provider metadata."
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "description": "security.txt",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found valid security.txt within the well-known directory"
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "description": "/.well-known/csaf/provider-metadata.json",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found /.well-known/csaf/provider-metadata.json"
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "description": "DNS path",
+          "messages": [
+            {
+              "type": 2,
+              "text": "Fetching https://csaf.data.security.intevation.de failed: Get \"https://csaf.data.security.intevation.de\": dial tcp: lookup csaf.data.security.intevation.de on 127.0.0.11:53: no such host"
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "description": "One folder per year",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All CSAF files are in the right folders."
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "description": "index.txt",
+          "messages": [
+            {
+              "type": 2,
+              "text": "Fetching index.txt failed: https://intevation.de/.well-known/csaf/index.txt not found."
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "description": "changes.csv",
+          "messages": [
+            {
+              "type": 2,
+              "text": "Fetching changes.csv failed: https://intevation.de/.well-known/csaf/changes.csv not found."
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "description": "Directory listings",
+          "messages": [
+            {
+              "type": 2,
+              "text": "Fetching https://intevation.de/.well-known/csaf/white/2024/ failed. Status code 403 (403 Forbidden)"
+            },
+            {
+              "type": 2,
+              "text": "Fetching https://intevation.de/.well-known/csaf/white/2026/ failed. Status code 403 (403 Forbidden)"
+            },
+            {
+              "type": 2,
+              "text": "Fetching https://intevation.de/.well-known/csaf/white/2025/ failed. Status code 403 (403 Forbidden)"
+            },
+            {
+              "type": 2,
+              "text": "Not listed advisories: https://intevation.de/.well-known/csaf/white/2024/intevation-os-2024-0001.json, https://intevation.de/.well-known/csaf/white/2025/intevation-os-2025-0001.json, https://intevation.de/.well-known/csaf/white/2025/intevation-os-2025-0002.json, https://intevation.de/.well-known/csaf/white/2025/intevation-os-2025-0003.json, https://intevation.de/.well-known/csaf/white/2025/intevation-os-2025-0004.json, https://intevation.de/.well-known/csaf/white/2026/intevation-openslides-2026-001.json"
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "description": "ROLIE feed",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All checked ROLIE feeds validated fine."
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "description": "ROLIE service document",
+          "messages": [
+            {
+              "type": 0,
+              "text": "ROLIE service document validated fine."
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "description": "ROLIE category document",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All checked ROLIE category documents exist."
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "description": "Integrity",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All checksums match."
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "description": "Signatures",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All signatures verified."
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "description": "Public OpenPGP Key",
+          "messages": [
+            {
+              "type": 0,
+              "text": "1 public OpenPGP key(s) loaded."
+            }
+          ]
+        }
+      ],
+      "passed": true,
+      "evaluated_rules": {
+        "condition": "all",
+        "includes": [
+          {
+            "condition": "all",
+            "includes": [
+              {
+                "condition": "all",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "requirement": 1,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 2,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 3,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 4,
+                    "passed": true
+                  }
+                ]
+              },
+              {
+                "condition": "all",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "requirement": 5,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 6,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 7,
+                    "passed": true
+                  }
+                ]
+              },
+              {
+                "condition": "one",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "requirement": 8,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 9,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 10,
+                    "passed": false
+                  }
+                ]
+              },
+              {
+                "condition": "one",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "includes": [
+                      {
+                        "condition": "all",
+                        "requirement": 11,
+                        "passed": true
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 12,
+                        "passed": false
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 13,
+                        "passed": false
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 14,
+                        "passed": false
+                      }
+                    ]
+                  },
+                  {
+                    "condition": "all",
+                    "includes": [
+                      {
+                        "condition": "all",
+                        "requirement": 15,
+                        "passed": true
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 16,
+                        "passed": true
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 17,
+                        "passed": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "condition": "all",
+            "includes": [
+              {
+                "condition": "all",
+                "requirement": 18,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 19,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 20,
+                "passed": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "version": "3.5.2-57-gf048ad9",
+  "date": "2026-06-30T07:43:40.47353666Z"
+}

--- a/frontend/tests/assets/intevation.de-result.json.license
+++ b/frontend/tests/assets/intevation.de-result.json.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2026 SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+SPDX-License-Identifier: Apache-2.0

--- a/frontend/tests/assets/isduba.github.io-result.json
+++ b/frontend/tests/assets/isduba.github.io-result.json
@@ -1,0 +1,421 @@
+{
+  "domains": [
+    {
+      "name": "isduba.github.io",
+      "publisher": {
+        "category": "vendor",
+        "name": "Isduba Development Community",
+        "namespace": "https://github.com/ISDuBA",
+        "contact_details": "Open public issues at https://github.com/ISDuBA or contact one of the recently active developers in confidence.",
+        "issuing_authority": "Developers of the Free Software ISDuBA"
+      },
+      "role": "csaf_trusted_provider",
+      "requirements": [
+        {
+          "num": 1,
+          "description": "Valid CSAF documents",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All advisories validated fine."
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "description": "Filename",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All found filenames are conforming."
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "description": "TLS",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All tested URLs were HTTPS."
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "description": "TLP:WHITE",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All advisories labeled TLP:WHITE were freely accessible."
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "description": "TLP:AMBER and TLP:RED",
+          "messages": [
+            {
+              "type": 0,
+              "text": "No advisories labeled TLP:AMBER or TLP:RED tested for accessibility."
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "description": "Redirects",
+          "messages": [
+            {
+              "type": 0,
+              "text": "No redirections found."
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "description": "provider-metadata.json",
+          "messages": [
+            {
+              "type": 1,
+              "text": "Unexpected situation while loading provider-metadata.json: Fetching \"https://isduba.github.io/.well-known/security.txt\" failed: 404 Not Found (404)"
+            },
+            {
+              "type": 1,
+              "text": "Unexpected situation while loading provider-metadata.json: Fetching \"https://isduba.github.io/security.txt\" failed: 404 Not Found (404)"
+            },
+            {
+              "type": 2,
+              "text": "The content type of https://isduba.github.io/.well-known/csaf/white/2026/isduba-2026-002.json should be 'application/json' but is 'application/json; charset=utf-8'"
+            },
+            {
+              "type": 2,
+              "text": "The content type of https://isduba.github.io/.well-known/csaf/white/2026/isduba-2026-001.json should be 'application/json' but is 'application/json; charset=utf-8'"
+            },
+            {
+              "type": 2,
+              "text": "The content type of https://isduba.github.io/.well-known/csaf/white/2025/isduba-2025-02.json should be 'application/json' but is 'application/json; charset=utf-8'"
+            },
+            {
+              "type": 2,
+              "text": "The content type of https://isduba.github.io/.well-known/csaf/white/2025/isduba-2025-01.json should be 'application/json' but is 'application/json; charset=utf-8'"
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "description": "security.txt",
+          "messages": [
+            {
+              "type": 2,
+              "text": "https://isduba.github.io/.well-known/security.txt: Fetching https://isduba.github.io/.well-known/security.txt failed. Status code 404 (404 Not Found)"
+            },
+            {
+              "type": 2,
+              "text": "https://isduba.github.io/security.txt: Fetching https://isduba.github.io/security.txt failed. Status code 404 (404 Not Found)"
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "description": "/.well-known/csaf/provider-metadata.json",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found /.well-known/csaf/provider-metadata.json"
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "description": "DNS path",
+          "messages": [
+            {
+              "type": 2,
+              "text": "Fetching https://csaf.data.security.isduba.github.io failed: Get \"https://csaf.data.security.isduba.github.io\": tls: failed to verify certificate: x509: certificate is valid for *.github.com, *.github.io, *.githubusercontent.com, github.com, github.io, githubusercontent.com, not csaf.data.security.isduba.github.io"
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "description": "One folder per year",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All CSAF files are in the right folders."
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "description": "index.txt",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found https://isduba.github.io/.well-known/csaf/white/index.txt"
+            },
+            {
+              "type": 2,
+              "text": "Fetching index.txt failed: https://isduba.github.io/.well-known/csaf/green/index.txt not found."
+            },
+            {
+              "type": 2,
+              "text": "Fetching index.txt failed: https://isduba.github.io/.well-known/csaf/amber/index.txt not found."
+            },
+            {
+              "type": 2,
+              "text": "Fetching index.txt failed: https://isduba.github.io/.well-known/csaf/red/index.txt not found."
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "description": "changes.csv",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found https://isduba.github.io/.well-known/csaf/white/changes.csv"
+            },
+            {
+              "type": 2,
+              "text": "Fetching changes.csv failed: https://isduba.github.io/.well-known/csaf/green/changes.csv not found."
+            },
+            {
+              "type": 2,
+              "text": "Fetching changes.csv failed: https://isduba.github.io/.well-known/csaf/amber/changes.csv not found."
+            },
+            {
+              "type": 2,
+              "text": "Fetching changes.csv failed: https://isduba.github.io/.well-known/csaf/red/changes.csv not found."
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "description": "Directory listings",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All directory listings are valid."
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "description": "ROLIE feed",
+          "messages": [
+            {
+              "type": 1,
+              "text": "No entries in https://isduba.github.io/.well-known/csaf/green/csaf-feed-tlp-green.json"
+            },
+            {
+              "type": 1,
+              "text": "No entries in https://isduba.github.io/.well-known/csaf/amber/csaf-feed-tlp-amber.json"
+            },
+            {
+              "type": 1,
+              "text": "No entries in https://isduba.github.io/.well-known/csaf/red/csaf-feed-tlp-red.json"
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "description": "ROLIE service document",
+          "messages": [
+            {
+              "type": 0,
+              "text": "ROLIE service document validated fine."
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "description": "ROLIE category document",
+          "messages": [
+            {
+              "type": 1,
+              "text": "Fetching https://isduba.github.io/.well-known/csaf/white/category-white.json failed. Status code 404 (404 Not Found)"
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "description": "Integrity",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All checksums match."
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "description": "Signatures",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All signatures verified."
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "description": "Public OpenPGP Key",
+          "messages": [
+            {
+              "type": 0,
+              "text": "1 public OpenPGP key(s) loaded."
+            }
+          ]
+        }
+      ],
+      "passed": false,
+      "evaluated_rules": {
+        "condition": "all",
+        "includes": [
+          {
+            "condition": "all",
+            "includes": [
+              {
+                "condition": "all",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "requirement": 1,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 2,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 3,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 4,
+                    "passed": true
+                  }
+                ]
+              },
+              {
+                "condition": "all",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "requirement": 5,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 6,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 7,
+                    "passed": false
+                  }
+                ]
+              },
+              {
+                "condition": "one",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "requirement": 8,
+                    "passed": false
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 9,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 10,
+                    "passed": false
+                  }
+                ]
+              },
+              {
+                "condition": "one",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "includes": [
+                      {
+                        "condition": "all",
+                        "requirement": 11,
+                        "passed": true
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 12,
+                        "passed": false
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 13,
+                        "passed": false
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 14,
+                        "passed": true
+                      }
+                    ]
+                  },
+                  {
+                    "condition": "all",
+                    "includes": [
+                      {
+                        "condition": "all",
+                        "requirement": 15,
+                        "passed": true
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 16,
+                        "passed": true
+                      },
+                      {
+                        "condition": "all",
+                        "requirement": 17,
+                        "passed": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "condition": "all",
+            "includes": [
+              {
+                "condition": "all",
+                "requirement": 18,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 19,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 20,
+                "passed": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "version": "3.5.2-57-gf048ad9",
+  "date": "2026-06-30T07:45:19.410213308Z"
+}

--- a/frontend/tests/assets/isduba.github.io-result.json.license
+++ b/frontend/tests/assets/isduba.github.io-result.json.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2026 SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+SPDX-License-Identifier: Apache-2.0

--- a/frontend/tests/assets/www.innomic.com-result.json
+++ b/frontend/tests/assets/www.innomic.com-result.json
@@ -1,0 +1,344 @@
+{
+  "domains": [
+    {
+      "name": "https://www.innomic.com/.well-known/csaf/provider-metadata.json",
+      "publisher": {
+        "category": "vendor",
+        "name": "IDS Innomic Schwingungsmesstechnik GmbH",
+        "namespace": "https://www.innomic.com",
+        "contact_details": "IDS Innomic Schwingungsmesstechnik GmbH\n\nAddress:\nZum Buchhorst 35\n29410 Salzwedel\nGermany\n\nE-mail: info(at)innomic.de",
+        "issuing_authority": "IDS Innomic Schwingungsmesstechnik GmbH PSIRT is responsible for vulnerability handling across all IDS Innomic Schwingungsmesstechnik GmbH products and services."
+      },
+      "role": "csaf_provider",
+      "requirements": [
+        {
+          "num": 1,
+          "description": "Valid CSAF documents",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All advisories validated fine."
+            }
+          ]
+        },
+        {
+          "num": 2,
+          "description": "Filename",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All found filenames are conforming."
+            }
+          ]
+        },
+        {
+          "num": 3,
+          "description": "TLS",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All tested URLs were HTTPS."
+            }
+          ]
+        },
+        {
+          "num": 4,
+          "description": "TLP:WHITE",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All advisories labeled TLP:WHITE were freely accessible."
+            }
+          ]
+        },
+        {
+          "num": 5,
+          "description": "TLP:AMBER and TLP:RED",
+          "messages": [
+            {
+              "type": 0,
+              "text": "No advisories labeled TLP:AMBER or TLP:RED tested for accessibility."
+            }
+          ]
+        },
+        {
+          "num": 6,
+          "description": "Redirects",
+          "messages": [
+            {
+              "type": 0,
+              "text": "No redirections found."
+            }
+          ]
+        },
+        {
+          "num": 7,
+          "description": "provider-metadata.json",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found good provider metadata."
+            }
+          ]
+        },
+        {
+          "num": 8,
+          "description": "security.txt",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Performed no test of security.txt since the direct url of the provider-metadata.json was used."
+            }
+          ]
+        },
+        {
+          "num": 9,
+          "description": "/.well-known/csaf/provider-metadata.json",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Performed no test on whether the provider-metadata.json is available under the .well-known path since the direct url of the provider-metadata.json was used."
+            }
+          ]
+        },
+        {
+          "num": 10,
+          "description": "DNS path",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Performed no test on the contents of https://csaf.data.security.DOMAIN since the direct url of the provider-metadata.json was used."
+            }
+          ]
+        },
+        {
+          "num": 11,
+          "description": "One folder per year",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All CSAF files are in the right folders."
+            }
+          ]
+        },
+        {
+          "num": 12,
+          "description": "index.txt",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found https://www.innomic.com/.well-known/csaf/white/index.txt"
+            }
+          ]
+        },
+        {
+          "num": 13,
+          "description": "changes.csv",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Found https://www.innomic.com/.well-known/csaf/white/changes.csv"
+            }
+          ]
+        },
+        {
+          "num": 14,
+          "description": "Directory listings",
+          "messages": [
+            {
+              "type": 0,
+              "text": "All directory listings are valid."
+            }
+          ]
+        },
+        {
+          "num": 15,
+          "description": "ROLIE feed",
+          "messages": [
+            {
+              "type": 2,
+              "text": "ROLIE feed based distribution was not used."
+            }
+          ]
+        },
+        {
+          "num": 16,
+          "description": "ROLIE service document",
+          "messages": [
+            {
+              "type": 1,
+              "text": "No ROLIE service document found."
+            }
+          ]
+        },
+        {
+          "num": 17,
+          "description": "ROLIE category document",
+          "messages": [
+            {
+              "type": 1,
+              "text": "No ROLIE category document found."
+            }
+          ]
+        },
+        {
+          "num": 18,
+          "description": "Integrity",
+          "messages": [
+            {
+              "type": 0,
+              "text": "Fetching https://www.innomic.com/.well-known/csaf/white/2026/ids-2026-0001.json.sha256 failed: Status code 404 (404 Not Found)"
+            },
+            {
+              "type": 0,
+              "text": "Fetching https://www.innomic.com/.well-known/csaf/white/2026/ids-2026-0001.json.sha512 failed: Status code 404 (404 Not Found)"
+            }
+          ]
+        },
+        {
+          "num": 19,
+          "description": "Signatures",
+          "messages": [
+            {
+              "type": 2,
+              "text": "Fetching https://www.innomic.com/.well-known/csaf/white/2026/ids-2026-0001.json.asc failed: status code 404 (404 Not Found)"
+            }
+          ]
+        },
+        {
+          "num": 20,
+          "description": "Public OpenPGP Key",
+          "messages": [
+            {
+              "type": 1,
+              "text": "No public OpenPGP keys found: unknown key public_openpgp_keys."
+            }
+          ]
+        }
+      ],
+      "passed": true,
+      "evaluated_rules": {
+        "condition": "all",
+        "includes": [
+          {
+            "condition": "all",
+            "includes": [
+              {
+                "condition": "all",
+                "requirement": 1,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 2,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 3,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 4,
+                "passed": true
+              }
+            ]
+          },
+          {
+            "condition": "all",
+            "includes": [
+              {
+                "condition": "all",
+                "requirement": 5,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 6,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 7,
+                "passed": true
+              }
+            ]
+          },
+          {
+            "condition": "one",
+            "includes": [
+              {
+                "condition": "all",
+                "requirement": 8,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 9,
+                "passed": true
+              },
+              {
+                "condition": "all",
+                "requirement": 10,
+                "passed": true
+              }
+            ]
+          },
+          {
+            "condition": "one",
+            "includes": [
+              {
+                "condition": "all",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "requirement": 11,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 12,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 13,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 14,
+                    "passed": true
+                  }
+                ]
+              },
+              {
+                "condition": "all",
+                "includes": [
+                  {
+                    "condition": "all",
+                    "requirement": 15,
+                    "passed": false
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 16,
+                    "passed": true
+                  },
+                  {
+                    "condition": "all",
+                    "requirement": 17,
+                    "passed": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "version": "3.5.2-57-gf048ad9",
+  "date": "2026-06-30T07:44:43.047933289Z"
+}

--- a/frontend/tests/assets/www.innomic.com-result.json.license
+++ b/frontend/tests/assets/www.innomic.com-result.json.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2026 SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Implements compatibility with https://github.com/gocsaf/csaf/pull/741
Use the evaluation trail to determine which properties are relevant to show to the user and hide the irrelevant ones

this obsoletes the previous workaround (https://github.com/csaf-tools/provider-online-check/pull/95) by a more flexible and universal solution

also makes it more transparent to the user which requirements passed and which failed with the background color

The button "Show all messages" still shows all messages, also the requirements considered not relevant.

Frontend test covered changes from 76.53% to 76.24% of lines

@s-l-teichmann please review the tests in file `frontend/src/evaluatedRules.spec.ts` and the logic in `frontend/src/evaluatedRules.ts`.