### PR TITLE
feat: add cli status tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,8 @@ restrict-network:
 
 persist-restrict-network:
 	netfilter-persistent save
+
+# Status
+
+status:
+	docker compose exec backend ./status.py

--- a/README.md
+++ b/README.md
@@ -274,6 +274,42 @@ a2enmod proxy proxy_http ssl headers
 systemctl restart apache2
 ```
 
+### Status script
+
+A small status script for system administrators shows them the current activity and cache content.
+Run it from inside the backend container:
+
+```shell
+docker compose exec backend ./status.py
+```
+
+Or short with `make`:
+```shell
+make status
+```
+
+The output shows the current health, the currently running checks and cached results:
+
+```
+=== System Health ===
+Status:     healthy
+Free slots: 9 / 10
+csaf_checker_available: True
+valkey_available: True
+validator_available: True
+
+=== Running Scans ===
+Slot  Domain                          Status                Files     Running  Started (UTC)
+   0  redhat.com                      RUNNING_CHECKER          13          2s  2026-07-24T17:49:24
+9 slot(s) idle
+
+=== Cached Check results ===
+Domain                          Result  Role                       Duration  Started (UTC)        Expires (UTC)
+example.com                       FAIL  -                                0s  2026-07-24T17:46:10  2026-07-31T17:46:10
+cert-bund.de                      FAIL  csaf_trusted_provider        8m 13s  2026-07-24T17:35:26  2026-07-31T17:43:39
+intevation.de                     PASS  csaf_trusted_provider            1s  2026-07-24T17:34:01  2026-07-31T17:34:02
+```
+
 ### Blocking Domains
 
 Operators can block certain domains, preventing scans of them entirely.

--- a/backend/src/router/admin_status_response.py
+++ b/backend/src/router/admin_status_response.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+# Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SlotStatusEntry(BaseModel):
+    id: Annotated[int, Field(description="Slot ID")]
+    available: Annotated[bool, Field(description="If available / has a task")]
+    domain: Annotated[Optional[str], Field(description="Domain being checked")] = None
+    status: Annotated[Optional[str], Field(description="Scan status")] = None
+    start_time: Annotated[Optional[int], Field(description="Task start timestamp")] = None
+    files_checked: Annotated[Optional[int], Field(description="Number of files checked")] = None
+    latest_file_checked: Annotated[Optional[str], Field(description="Last checked file URL")] = None
+
+
+class AdminStatusResponse(BaseModel):
+    slots: Annotated[list[SlotStatusEntry], Field(description="State of all scan slots")]

--- a/backend/src/router/router.py
+++ b/backend/src/router/router.py
@@ -23,6 +23,7 @@ from ..csaf.csaf_checker import CSAF_BINARY_PATH, CSAF_CHECKER_BINARY
 from ..database.database import Database_Manager
 from ..database.valkey import Valkey_Controller
 from ..slots.slot_manager import Slot_Manager
+from .admin_status_response import AdminStatusResponse, SlotStatusEntry
 from .health_response import HealthResponse
 from .information_response import InformationResponse
 from .scan_request import ScanRequest
@@ -155,6 +156,34 @@ async def start_scan(request: ScanRequest) -> ScanResponse:
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to start scan: {str(e)}")
+
+
+@router.get(
+    "/admin/status",
+    response_model=AdminStatusResponse,
+    summary="System and Slot status",
+    description="Current state of all scan slots. Only for sysadmin use.",
+    tags=["devops"],
+    include_in_schema=False,
+)
+async def admin_status() -> AdminStatusResponse:
+    slots = []
+    for slot in Slot_Manager().slots:
+        available = slot.is_available()
+        if not available and slot.running_task is not None:
+            data = slot.running_task.get_data(True)
+            slots.append(SlotStatusEntry(
+                id=slot.id,
+                available=False,
+                domain=data.domain,
+                status=slot.running_task.get_status().name,
+                start_time=data.start_time,
+                files_checked=data.files_checked,
+                latest_file_checked=data.latest_file_checked or None,
+            ))
+        else:
+            slots.append(SlotStatusEntry(id=slot.id, available=True))
+    return AdminStatusResponse(slots=slots)
 
 
 @router.get(

--- a/backend/status.py
+++ b/backend/status.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+# Software-Engineering: 2026 Intevation GmbH <https://intevation.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Status tool for sysadmins
+# Run from inside the backend container:
+#
+#   docker compose exec backend ./status.py
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pprint import pprint
+from typing import Optional
+
+import httpx2
+import valkey
+
+# currently all of them are static
+BACKEND_URL = "http://localhost:8000"
+VALKEY_HOST = "valkey"
+VALKEY_PORT = 6379
+
+RECORDED_DOMAIN_TASK_BY_UUID = "domain-task-id-to-domain:"  # keep in sync with src/database/valkey.py
+CACHE_LIFETIME = int(os.environ.get("CACHE_TIMEOUT_SECONDS", "604800"))
+
+
+def fmt_ts(ts: Optional[int]) -> str:
+    if not ts:
+        return "-"
+    # remove trailing +00:00, is always UTC anyway
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()[:-6]
+
+
+def fmt_duration(seconds: int) -> str:
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m {seconds:02d}s"
+    if minutes:
+        return f"{minutes}m {seconds:02d}s"
+    return f"{seconds}s"
+
+
+def section(title: str):
+    print(f"\n=== {title} ===")
+
+
+def print_health(client: httpx2.Client):
+    section("System Health")
+    try:
+        request = client.get(f"{BACKEND_URL}/api/health", timeout=5)
+        health = request.json()
+    except Exception as exc:
+        print(f"  Could not reach backend: {exc}")
+        return
+
+    print(f"Status:     {health.get('status', '?')}")
+    print(f"Free slots: {health.get('free_slots', '?')} / {health.get('total_slots', '?')}")
+
+    for key in ("csaf_checker_available", "valkey_available",
+                "validator_available"):
+        print(f"{key}: {health.get(key)}")
+
+    if health.get("errors"):
+        for error in health["errors"]:
+            print(f"  ! {error}")
+
+
+def print_running(client: httpx2.Client):
+    section("Running Scans")
+    try:
+        request = client.get(f"{BACKEND_URL}/api/admin/status", timeout=5)
+        data = request.json()
+    except Exception as exc:
+        print(f"  Could not reach backend: {exc}")
+        return
+
+    slots = data.get("slots", [])
+    active_slots = [slot for slot in slots if not slot["available"]]
+    idle_count = len(slots) - len(active_slots)
+
+    if active_slots:
+        now = int(datetime.now(tz=timezone.utc).timestamp())
+        print(f"{'Slot':>4}  {'Domain':<30}  {'Status':<20}  {'Files':>5}  {'Running':>10}  Started (UTC)")
+        for slot in active_slots:
+            start = slot.get('start_time') or 0
+            print(
+                f"{slot['id']:>4}  {slot.get('domain') or '':<30}  "
+                f"{slot.get('status') or '':<20}  "
+                f"{slot.get('files_checked') or 0:>5}  "
+                f"{fmt_duration(now - start) if start else '-':>10}  "
+                f"{fmt_ts(start)}"
+            )
+    print(f"{idle_count} slot(s) idle")
+
+
+def print_cached():
+    section("Cached Check results")
+    try:
+        cache = valkey.Valkey(host=VALKEY_HOST, port=VALKEY_PORT, db=0, protocol=3)
+        keys = cache.keys(RECORDED_DOMAIN_TASK_BY_UUID + "*")
+    except Exception as exc:
+        print(f"  Could not reach cache: {exc}")
+        return
+
+    tasks = []
+    for key in keys:
+        raw = cache.get(key)
+        if not raw:
+            continue
+        try:
+            t = json.loads(raw)
+            tasks.append(t)
+        except Exception as exc:
+            print(f"  Error decoding key {key!r}: {exc}")
+            continue
+
+    tasks.sort(key=lambda t: t.get("start_time", 0), reverse=True)
+
+    if not tasks:
+        print("  No cached scans.")
+        return
+
+    print(
+        f"{'Domain':<30}  {'Result':>6}  {'Role':<25}  {'Duration':>8}  "
+        f"{'Started (UTC)':<19}  {'Expires (UTC)':<19}"
+    )
+    for t in tasks:
+        domain = t.get("domain", "?")
+        start = t.get("start_time")
+        end = t.get("end_time")
+        duration = fmt_duration(end - start) if end and start else 'unknown'
+        expires = fmt_ts(end + CACHE_LIFETIME) if end else 'unknown'
+
+        passed = None
+        role = None
+        result_json = t.get("csaf_checker_output_result", "")
+        if result_json:
+            try:
+                result = json.loads(result_json)
+                domains = result.get("domains", [])
+                if domains:
+                    passed = domains[0].get("passed")
+                    role = domains[0].get("role")
+            except Exception as exc:
+                print(f"  Error decoding result JSON of domain {domain!r}: {exc}")
+                pass
+
+        result_str = "PASS" if passed is True else "FAIL"
+        role_str = role or "-"
+
+        print(
+            f"{domain:<30}  {result_str:>6}  {role_str:<25}  {duration:>8}  "
+            f"{fmt_ts(start):<19}  {expires:<19}"
+        )
+
+
+def main():
+    with httpx2.Client() as client:
+        print_health(client)
+        print_running(client)
+    print_cached()
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/status.py
+++ b/backend/status.py
@@ -13,7 +13,6 @@ import json
 import os
 import sys
 from datetime import datetime, timezone
-from pprint import pprint
 from typing import Optional
 
 import httpx2

--- a/contrib/apache-site.conf
+++ b/contrib/apache-site.conf
@@ -50,6 +50,11 @@ MDCertificateAgreement accepted
         Include /etc/apache2/conf-available/blocklist-cidr.conf
     </Location>
 
+    # Admin endpoints are only accessible from localhost
+    <Location /api/admin>
+        Require local
+    </Location>
+
     # Backend API
     ProxyPass /blocked.html !
     ProxyPass /api http://localhost:48090/api


### PR DESCRIPTION
shows which tasks are running and their status, as well as cached checks

fixes first part of #16

Looks like this then:

```
=== System Health ===
Status:     healthy
Free slots: 9 / 10
csaf_checker_available: True
valkey_available: True
validator_available: True

=== Running Scans ===
Slot  Domain                          Status                Files     Running  Started (UTC)
   0  redhat.com                      RUNNING_CHECKER          13          2s  2026-07-24T17:49:24
9 slot(s) idle

=== Cached Check results ===
Domain                          Result  Role                       Duration  Started (UTC)        Expires (UTC)      
example.com                       FAIL  -                                0s  2026-07-24T17:46:10  2026-07-31T17:46:10
cert-bund.de                      FAIL  csaf_trusted_provider        8m 13s  2026-07-24T17:35:26  2026-07-31T17:43:39
www.innomic.com                   PASS  csaf_provider                    0s  2026-07-24T17:34:38  2026-07-31T17:34:38
intevation.de                     PASS  csaf_trusted_provider            1s  2026-07-24T17:34:01  2026-07-31T17:34:02
```