### PR TITLE
fix: ignore backend/bin in docker

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -28,6 +28,9 @@ ENV/
 .git/
 .gitignore
 
+# ignore pre-compiled csaf_checker: always build inside the image via build_gocsaf.sh
+bin/
+
 # Documentation
 README.md
 


### PR DESCRIPTION
Avoid that the host's executables in backend/bin shadow the binaries built in the container.

I just had to debug a sitation with the prod environment where the csaf_checker did not get the new version (set by CSAF_REF) and was instead stuck with the old one.