### PR TITLE
feat: Mirroring CSAF Checkers client_timeout parameter

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,7 @@ PORT_VALIDATOR=48092
 #VITE_BACKEND_PORT=$PORT_BACKEND
 
 ## Component Version
-CSAF_CHECKER_VERSION=3.5.1
+CSAF_CHECKER_VERSION=3.6.0
 CSAF_VALIDATOR_VERSION=2.0.25
 APP_VERSION=0.3.0
 # The expected checksum of the gocsaf tarball, used in production builds for verification
@@ -20,7 +20,7 @@ CSAF_SHA256=62995edf30703bed8c7fd2de4c5aec7692b47c8c66e5d8bdc04e6936b9185c60
 ## gocsaf source build
 ## Set to a branch name, tag, or commit SHA to build csaf_checker from source
 ## Requires at least 400m memory in the backend container (env BACKEND_MEMORY_LIMIT)
-CSAF_REF=f048ad9
+CSAF_REF=974be17
 
 ## Scan Slots
 SCAN_SLOTS=10
@@ -50,6 +50,7 @@ CACHE_TIMEOUT_SECONDS=604800
 VALIDATOR_CACHE_RESULTS=1
 
 ## Task Options
+TASK_CSAF_CLIENT_TIMEOUT=30s
 TASK_PAUSE_TIME_MAX_BEFORE_RESET=100
 TASK_PAUSE_TIME_INTERVAL=0.2
 TASK_TIME_BEFORE_ORPHANED=50

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Docker Compose reads this file automatically.
 | `CSAF_CHECKER_TIMEOUT` | Timeout for csaf_checker in seconds, 0 for unlimited. |
 | `CACHE_TIMEOUT_SECONDS` | Lifetime of a cached csaf_checker result. |
 | `VALIDATOR_CACHE_RESULTS` | Enables validator output to be saved as cache files. 1 is enabled, 0 disabled. |
+| `TASK_CSAF_CLIENT_TIMEOUT` | Timeout for target domain requests. Mirrors CSAF Checkers 'client_timeout' parameter. Format example: '30s' for 30 seconds. |
 | `TASK_PAUSE_TIME_MAX_BEFORE_RESET` | Maximum time in seconds before a paused task is forced to stop. |
 | `TASK_PAUSE_TIME_INTERVAL` | Second interval where the status of a paused task is queried. |
 | `TASK_TIME_BEFORE_ORPHANED` | Time in seconds a task can run without it's status being requested by a user before being considered orphaned. |

--- a/backend/src/csaf/csaf_checker.py
+++ b/backend/src/csaf/csaf_checker.py
@@ -59,6 +59,13 @@ class CSAF_Checker(BaseModel):
         Field(description="Asynchronous task running csaf checker"),
     ] = None
 
+    _csaf_client_timeout: Annotated[
+        str,
+        Field(
+            description="Timeout for target domain requests. Mirrors CSAF Checkers 'client_timeout' parameter."
+        ),
+    ] = str(os.environ.get("TASK_CSAF_CLIENT_TIMEOUT", "30s"))
+
     _max_wait_time: Annotated[
         int,
         Field(
@@ -106,6 +113,10 @@ class CSAF_Checker(BaseModel):
                 args.append(
                     f"--validator_cache={CACHE_PATH_VALIDATOR}{data.validator_cache_file}"
                 )
+        
+        args.append(
+            f"--client_timeout={self._csaf_client_timeout}"
+        )
 
         # Write args. `--` before the domain ensures it is treated as a positional
         # argument and not a flag, even if it starts with `-`.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,7 @@ services:
       - CSAF_CHECKER_TIMEOUT=${CSAF_CHECKER_TIMEOUT:-3600}
       - DOMAIN_BLOCKLIST=${DOMAIN_BLOCKLIST:-}
       - VALIDATOR_CACHE_RESULTS=${VALIDATOR_CACHE_RESULTS:-1}
+      - TASK_CSAF_CLIENT_TIMEOUT=${TASK_CSAF_CLIENT_TIMEOUT:-30s}
       - TASK_PAUSE_TIME_MAX_BEFORE_RESET=${TASK_PAUSE_TIME_MAX_BEFORE_RESET:-100}
       - TASK_PAUSE_TIME_INTERVAL=${TASK_PAUSE_TIME_INTERVAL:-0.2}
       - TASK_TIME_BEFORE_ORPHANED=${TASK_TIME_BEFORE_ORPHANED:-50}
@@ -78,7 +79,7 @@ services:
       context: ./validator
       target: prod
       args:
-      - CSAF_VALIDATOR_VERSION=${CSAF_VALIDATOR_VERSION:?CSAF_VALIDATOR_VERSION is not set}
+        - CSAF_VALIDATOR_VERSION=${CSAF_VALIDATOR_VERSION:?CSAF_VALIDATOR_VERSION is not set}
     container_name: validator
     ports:
       - "${PORT_VALIDATOR:-48092}:8082"
@@ -92,7 +93,8 @@ services:
     depends_on:
       - valkey
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://0.0.0.0:8082/api/v1/tests"]
+      test:
+        ["CMD", "wget", "-q", "--spider", "http://0.0.0.0:8082/api/v1/tests"]
       interval: 15s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - CSAF_CHECKER_TIMEOUT=${CSAF_CHECKER_TIMEOUT:-3600}
       - DOMAIN_BLOCKLIST=${DOMAIN_BLOCKLIST:-}
       - VALIDATOR_CACHE_RESULTS=${VALIDATOR_CACHE_RESULTS:-1}
+      - TASK_CSAF_CLIENT_TIMEOUT=${TASK_CSAF_CLIENT_TIMEOUT:-30s}
       - TASK_PAUSE_TIME_MAX_BEFORE_RESET=${TASK_PAUSE_TIME_MAX_BEFORE_RESET:-100}
       - TASK_PAUSE_TIME_INTERVAL=${TASK_PAUSE_TIME_INTERVAL:-0.2}
       - TASK_TIME_BEFORE_ORPHANED=${TASK_TIME_BEFORE_ORPHANED:-50}
@@ -82,7 +83,7 @@ services:
       context: ./validator
       target: dev
       args:
-      - CSAF_VALIDATOR_VERSION=${CSAF_VALIDATOR_VERSION:?CSAF_VALIDATOR_VERSION is not set}
+        - CSAF_VALIDATOR_VERSION=${CSAF_VALIDATOR_VERSION:?CSAF_VALIDATOR_VERSION is not set}
     container_name: validator
     ports:
       - "${PORT_VALIDATOR:-48092}:8082"
@@ -96,7 +97,8 @@ services:
     depends_on:
       - valkey
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://0.0.0.0:8082/api/v1/tests"]
+      test:
+        ["CMD", "wget", "-q", "--spider", "http://0.0.0.0:8082/api/v1/tests"]
       interval: 15s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Resolves https://github.com/csaf-tools/provider-online-check/issues/210#event-28707022772

Updating CSAF Checker version and hash to `3.6.0` was necessary for `client_timeout` functionality