### PR TITLE
feat: Allow scan reruns

### DIFF
--- a/backend/src/router/scan_request.py
+++ b/backend/src/router/scan_request.py
@@ -47,6 +47,13 @@ class ScanRequest(BaseModel):
         ),
     ] = False
 
+    observe_rerun: Annotated[
+        bool,
+        Field(
+            description="When enabled, the cache will be skipped, but no new task will be created either."
+        ),
+    ] = False
+
     clear_any_running: Annotated[
         bool,
         Field(

--- a/backend/src/slots/slot_manager.py
+++ b/backend/src/slots/slot_manager.py
@@ -78,21 +78,24 @@ class Slot_Manager:
         # Return that task id, if it exists (avoid working on the same domain twice)
         # Ignores completed tasks; Cache should be used instead if already done tasks are queried
         available_slot = None
+        domain_task_uuid = ""
         slot_with_identical_running_task = self.get_slot_by_domain(request.domain)
         if slot_with_identical_running_task is not None:
             if request.clear_any_running:
                 slot_with_identical_running_task.running_task.stop_task()
 
                 available_slot = slot_with_identical_running_task
-            elif not slot_with_identical_running_task.is_available():
-                logger.info(
-                    f"A task is already operating for {request.domain} in slot id {slot_with_identical_running_task.id}"
-                )
-                return slot_with_identical_running_task.running_task.get_data(
-                    False
-                ).uuid
             else:
                 available_slot = slot_with_identical_running_task
+                domain_task_uuid = slot_with_identical_running_task.running_task.get_data(
+                    False
+                ).uuid
+
+                if not slot_with_identical_running_task.is_available():
+                    logger.info(
+                        f"A task is already operating for {request.domain} in slot id {slot_with_identical_running_task.id}"
+                    )
+                    return domain_task_uuid
 
         # Find available slot
         if available_slot is None:
@@ -107,7 +110,7 @@ class Slot_Manager:
         )
 
         # Start Checker
-        if not request.observe_rerun:
+        if request.skip_cache or not request.observe_rerun:
             domain_task_uuid = available_slot.start_domain_task(request)
 
         return domain_task_uuid

--- a/backend/src/slots/slot_manager.py
+++ b/backend/src/slots/slot_manager.py
@@ -61,7 +61,7 @@ class Slot_Manager:
         Returns uuid of relevant domain task.
         """
         # Check database cache first
-        if not request.skip_cache:
+        if not request.skip_cache and not request.observe_rerun:
             cached_task_data = Database_Manager().load_task_by_domain(request.domain)
             if cached_task_data is not None:
                 if cached_task_data.cache_is_outdated():
@@ -76,6 +76,7 @@ class Slot_Manager:
 
         # Search for a running task that operates on the same domain
         # Return that task id, if it exists (avoid working on the same domain twice)
+        # Ignores completed tasks; Cache should be used instead if already done tasks are queried
         available_slot = None
         slot_with_identical_running_task = self.get_slot_by_domain(request.domain)
         if slot_with_identical_running_task is not None:
@@ -83,13 +84,15 @@ class Slot_Manager:
                 slot_with_identical_running_task.running_task.stop_task()
 
                 available_slot = slot_with_identical_running_task
-            else:
+            elif not slot_with_identical_running_task.is_available():
                 logger.info(
                     f"A task is already operating for {request.domain} in slot id {slot_with_identical_running_task.id}"
                 )
                 return slot_with_identical_running_task.running_task.get_data(
                     False
                 ).uuid
+            else:
+                available_slot = slot_with_identical_running_task
 
         # Find available slot
         if available_slot is None:
@@ -104,7 +107,8 @@ class Slot_Manager:
         )
 
         # Start Checker
-        domain_task_uuid = available_slot.start_domain_task(request)
+        if not request.observe_rerun:
+            domain_task_uuid = available_slot.start_domain_task(request)
 
         return domain_task_uuid
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -67,6 +67,17 @@ class TestInformationEndpoint:
         assert "openapi" in data
 
 
+class TestAdminEndpoint:
+    """Tests for the admin status endpoint"""
+
+    def test_admin_status(self):
+        """admin status endpoint returns expected fields"""
+        response = client.get("/api/admin/status")
+        data = response.json()
+        assert response.status_code == 200
+        assert "slots" in data
+        assert len(data["slots"]) == 10
+
 class TestHealthEndpoint:
     """Tests for the health check endpoint"""
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -45,7 +45,8 @@ SPDX-License-Identifier: Apache-2.0
                   <span><code>{{ domain }}</code></span>
                   <span v-if="loading" class="spinner-border spinner-border-sm ms-2 me-auto" role="status" aria-hidden="true"></span>
                   <span v-else class="ms-2 me-auto">✓</span>
-                  <button class="btn btn-danger btn-sm" @click="reset">{{ loading ? 'Cancel': 'Start a new check'}}</button>
+                  <button class="btn btn-warning btn-sm" @click="reset">{{ loading ? 'Cancel': 'Start a new check'}}</button>
+                  <button class="btn btn-danger btn-sm" v-if="!loading" @click="rescan">Rerun without cache</button>
                 </div>
                 <div v-if="result?.start_time">Duration {{ formatDuration(result?.start_time, result?.end_time) }}</div>
               </div>
@@ -319,8 +320,12 @@ export default defineComponent({
       .then(response => this.version = response.data)
     const params = new URLSearchParams(window.location.search)
     const domainParam = params.get('domain')
+    const observeRerun = params.get('observe_rerun')
+    this.observe_rerun = false
     if (domainParam) {
       this.domain = domainParam
+      if(observeRerun)
+        this.observe_rerun = observeRerun
       this.startScan()
     }
   },
@@ -399,16 +404,19 @@ export default defineComponent({
     async scanWork() {
       try {
         this.error = null
-        history.replaceState(null, '', `?domain=${encodeURIComponent(this.domain)}`)
+        history.replaceState(null, '', `?domain=${encodeURIComponent(this.domain)}&observe_rerun=${encodeURIComponent(this.observe_rerun)}`)
         const response = await axios.post(`${this.backendUrl}/api/scan/start`, {
           domain: this.domain,
-          session_id: this.session_id
+          session_id: this.session_id,
+          skip_cache: this.skip_cache,
+          observe_rerun: this.observe_rerun,
         })
         this.result = this.loading ? response.data: null
         if (this.result?.domain) {
           this.domain = this.result.domain
         }
         if (['DONE_CHECKER', 'CACHED_CHECKER'].includes(this.result?.status)) {
+          this.observe_rerun = false
           const parsedResultsChecker = this.parseResultsChecker(this.result.results_checker)
           this.extractMessagesFromResultsChecker(parsedResultsChecker)
           this.setScanTime(parsedResultsChecker)
@@ -437,7 +445,16 @@ export default defineComponent({
         }
       }
     },
+    rescan() {
+      this.skip_cache = true
+      this.observe_rerun = false
+      this.startScan()
+      this.skip_cache = false
+      this.observe_rerun = true
+    },
     reset() {
+      this.skip_cache = false
+      this.observe_rerun = false
       this.loading = false
       this.allowInput = true
       this.result = null

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -275,7 +275,6 @@ interface AppData {
   isShowCacheInfo: boolean;
   fetchLogCBStatus: string;
   fetchLogDLStatus: string;
-  skip_cache: boolean;
   observe_rerun: boolean;
   version: {
     csaf_checker_version: string;
@@ -314,7 +313,6 @@ export default defineComponent({
       isShowCacheInfo: false,
       fetchLogCBStatus: '',
       fetchLogDLStatus: '',
-      skip_cache: false,
       observe_rerun: false,
     } as AppData
   },
@@ -393,27 +391,36 @@ export default defineComponent({
     }
   },
   methods: {
-    async startScan() {
+    async startScan(skip_cache = false) {
       this.loading = true
       this.allowInput = false
       this.result = null
       this.messagesList = null
       this.error = null
       this.clearFields()
-      this.scanWork()
+      this.scanWork(skip_cache)
     },
-    async scanWork() {
+    async scanWork(skip_cache = false) {
       try {
+        let skipCache = false
+        if (typeof skip_cache === 'boolean') {
+          skipCache = skip_cache
+        }
+
         this.error = null
         const url = `?domain=${encodeURIComponent(this.domain)}` + (this.observe_rerun ? '&observe_rerun=true' : '')
         history.replaceState(null, '', url)
         const response = await axios.post(`${this.backendUrl}/api/scan/start`, {
           domain: this.domain,
           session_id: this.session_id,
-          skip_cache: this.skip_cache,
+          skip_cache: skipCache,
           observe_rerun: this.observe_rerun,
         })
-        this.skip_cache = false
+
+        if ( skipCache ) {
+          this.observe_rerun = true
+        }
+
         this.result = this.loading ? response.data: null
         if (this.result?.domain) {
           this.domain = this.result.domain
@@ -449,12 +456,9 @@ export default defineComponent({
       }
     },
     rescan() {
-      this.skip_cache = true
-      this.observe_rerun = true
-      this.startScan()
+      this.startScan(true)
     },
     reset() {
-      this.skip_cache = false
       this.observe_rerun = false
       this.loading = false
       this.allowInput = true

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -275,6 +275,8 @@ interface AppData {
   isShowCacheInfo: boolean;
   fetchLogCBStatus: string;
   fetchLogDLStatus: string;
+  skip_cache: boolean;
+  observe_rerun: boolean;
   version: {
     csaf_checker_version: string;
     csaf_validator_version: string;
@@ -312,6 +314,8 @@ export default defineComponent({
       isShowCacheInfo: false,
       fetchLogCBStatus: '',
       fetchLogDLStatus: '',
+      skip_cache: false,
+      observe_rerun: false,
     } as AppData
   },
   async mounted() {
@@ -320,12 +324,9 @@ export default defineComponent({
       .then(response => this.version = response.data)
     const params = new URLSearchParams(window.location.search)
     const domainParam = params.get('domain')
-    const observeRerun = params.get('observe_rerun')
-    this.observe_rerun = false
     if (domainParam) {
       this.domain = domainParam
-      if(observeRerun)
-        this.observe_rerun = observeRerun
+      this.observe_rerun = params.get('observe_rerun') === 'true'
       this.startScan()
     }
   },
@@ -404,13 +405,15 @@ export default defineComponent({
     async scanWork() {
       try {
         this.error = null
-        history.replaceState(null, '', `?domain=${encodeURIComponent(this.domain)}&observe_rerun=${encodeURIComponent(this.observe_rerun)}`)
+        const url = `?domain=${encodeURIComponent(this.domain)}` + (this.observe_rerun ? '&observe_rerun=true' : '')
+        history.replaceState(null, '', url)
         const response = await axios.post(`${this.backendUrl}/api/scan/start`, {
           domain: this.domain,
           session_id: this.session_id,
           skip_cache: this.skip_cache,
           observe_rerun: this.observe_rerun,
         })
+        this.skip_cache = false
         this.result = this.loading ? response.data: null
         if (this.result?.domain) {
           this.domain = this.result.domain
@@ -447,10 +450,8 @@ export default defineComponent({
     },
     rescan() {
       this.skip_cache = true
-      this.observe_rerun = false
-      this.startScan()
-      this.skip_cache = false
       this.observe_rerun = true
+      this.startScan()
     },
     reset() {
       this.skip_cache = false


### PR DESCRIPTION
A scan once cached can not be restarted by a user to reduce backend load. However this makes active development of CSAF Providers near impossible as the long cache lifetime hinders checking newly updated data.

This PR allows users to restart a scan without using cache. The restarted scan runs on top of the cached scan. The user can observe the restarted scan and hence check their newly updated CSAF Provider. 

Crucially the cache is still present. Another user who scans a domain that has already been restarted (with the restart still ongoing) will not start yet another scan or see the rerun scan; instead they will instead see the originally cached version. When a second rerun is started on an already running rerun, the first rerun will be displayed instead of starting a new scan.
Once the rerun is complete, it will overwrite the original cache.

This should fix concerns brought up in https://github.com/csaf-tools/provider-online-check/issues/203 , https://github.com/csaf-tools/provider-online-check/issues/212 and https://github.com/csaf-tools/provider-online-check/issues/219