### PR TITLE
Named volume for validator cache

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -104,6 +104,7 @@ services:
       - scanner
     volumes:
       - valkey-data:/data
+      - validator-store:/app/store/validator/cache/
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 30s
@@ -117,6 +118,7 @@ services:
 
 volumes:
   valkey-data:
+  validator-store:
 
 networks:
   scanner:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - "${PORT_BACKEND:-443}:8000"
     volumes:
       - ./backend:/app
+      - validator-store:/app/store/validator/cache/
     environment:
       - SCAN_SLOTS=${SCAN_SLOTS:-10}
       - CSAF_CHECKER_TIMEOUT=${CSAF_CHECKER_TIMEOUT:-3600}
@@ -124,3 +125,6 @@ networks:
         # these must match the source ranges in dev/restrict-network.sh
         - subnet: 172.30.0.0/24
         - subnet: fd00:30::/64
+
+volumes:
+  validator-store: {}


### PR DESCRIPTION
The cache has been written with root rights to the backend folder because of the volume bind mount. This caused permission errors. Contents of the validator cache are now moved into their own named volume instead to prevent this.
Resolves https://github.com/csaf-tools/provider-online-check/issues/140