### PR TITLE
release 0.4.0

### DIFF
--- a/.env
+++ b/.env
@@ -13,9 +13,9 @@ PORT_VALIDATOR=48092
 ## Component Version
 CSAF_CHECKER_VERSION=3.6.0
 CSAF_VALIDATOR_VERSION=2.0.31
-APP_VERSION=0.3.0
-# The expected checksum of the gocsaf tarball, used in production builds for verification
-CSAF_SHA256=62995edf30703bed8c7fd2de4c5aec7692b47c8c66e5d8bdc04e6936b9185c60
+APP_VERSION=0.4.0
+# The expected checksum of the gocsaf tarball (gnulinux-amd64), used in production builds for verification
+CSAF_SHA256=020d212ef7cb993d5aaea223801e0528bd902c0080e3f114d7f255e8bdb87ebf
 
 ## gocsaf source build
 ## Set to a branch name, tag, or commit SHA to build csaf_checker from source

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csaf-provider-scan-frontend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CSAF Provider Scan Frontend",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
and use the latest gocsaf release by version number, not be git reference (at the time of our last gocsaf version update, it wasn't yet tagged)

closes https://github.com/csaf-tools/provider-online-check/issues/245